### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix insecure temporary file creation

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-18 - Insecure Temporary File Creation
+**Vulnerability:** Predictable temporary files in `/tmp` (e.g. `/tmp/script.sh.new`) were used to download script updates. Since these scripts run as root, this allowed for symlink attacks and local privilege escalation.
+**Learning:** Shell scripts downloading remote payloads must use `mktemp` to generate secure, unpredictable temporary files to prevent symlink attacks in world-writable directories.
+**Prevention:** Always use `mktemp` to create temporary files in bash scripts running with elevated privileges.

--- a/lxc-updater.sh
+++ b/lxc-updater.sh
@@ -157,7 +157,8 @@ auto_update() {
 
   local script_name
   script_name="$(basename "${BASH_SOURCE[0]}")"
-  local tmp_file="/tmp/${script_name}.new"
+  local tmp_file
+  tmp_file=$(mktemp "/tmp/${script_name}.XXXXXX") || return 1
 
   if curl -sL --connect-timeout 5 --max-time 30 \
     -o "$tmp_file" \

--- a/pve-update-notifier.sh
+++ b/pve-update-notifier.sh
@@ -129,7 +129,8 @@ auto_update() {
 
   local script_name
   script_name="$(basename "${BASH_SOURCE[0]}")"
-  local tmp_file="/tmp/${script_name}.new"
+  local tmp_file
+  tmp_file=$(mktemp "/tmp/${script_name}.XXXXXX") || return 1
 
   if curl -sL --connect-timeout 5 --max-time 30 \
     -o "$tmp_file" \

--- a/system-update-notifier.sh
+++ b/system-update-notifier.sh
@@ -92,7 +92,8 @@ auto_update() {
 
   local script_name
   script_name="$(basename "${BASH_SOURCE[0]}")"
-  local tmp_file="/tmp/${script_name}.new"
+  local tmp_file
+  tmp_file=$(mktemp "/tmp/${script_name}.XXXXXX") || return 1
 
   if curl -sL --connect-timeout 5 --max-time 30 \
     -o "$tmp_file" \


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** The auto-update functionality across `lxc-updater.sh`, `pve-update-notifier.sh`, and `system-update-notifier.sh` used predictable, hardcoded temporary files (e.g., `/tmp/${script_name}.new`). Because these scripts execute with root privileges, this opened up a vulnerability to local privilege escalation or arbitrary file overwriting via symlink attacks. 
🎯 **Impact:** An unprivileged attacker could create a symbolic link at the predictable path pointing to a critical system file. When the script downloads its update, it would overwrite the critical file with the remote payload.
🔧 **Fix:** Refactored the update download logic to generate secure, unguessable temporary files using `mktemp`.
✅ **Verification:** 
- The auto-updater functions now securely execute `tmp_file=$(mktemp "/tmp/${script_name}.XXXXXX") || return 1`.
- Verified script syntax using `bash -n`.

---
*PR created automatically by Jules for task [4515906565530617738](https://jules.google.com/task/4515906565530617738) started by @spupuz*