### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix insecure temporary file creation (symlink attacks)

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2026-07-21 - [Insecure Temporary Files in Shell Scripts]
+**Vulnerability:** Shell scripts using static or predictable paths for temporary files (e.g., `/tmp/${script_name}.new`).
+**Learning:** This exposes the system to symlink attacks, allowing local privilege escalation, especially for scripts running with elevated (root) privileges as in this repository.
+**Prevention:** Always use `mktemp` (e.g., `tmp_file=$(mktemp "/tmp/script.XXXXXX")`) to create temporary files in shell scripts.

--- a/lxc-updater.sh
+++ b/lxc-updater.sh
@@ -157,7 +157,8 @@ auto_update() {
 
   local script_name
   script_name="$(basename "${BASH_SOURCE[0]}")"
-  local tmp_file="/tmp/${script_name}.new"
+  local tmp_file
+  tmp_file=$(mktemp "/tmp/${script_name}.XXXXXX")
 
   if curl -sL --connect-timeout 5 --max-time 30 \
     -o "$tmp_file" \

--- a/pve-update-notifier.sh
+++ b/pve-update-notifier.sh
@@ -129,7 +129,8 @@ auto_update() {
 
   local script_name
   script_name="$(basename "${BASH_SOURCE[0]}")"
-  local tmp_file="/tmp/${script_name}.new"
+  local tmp_file
+  tmp_file=$(mktemp "/tmp/${script_name}.XXXXXX")
 
   if curl -sL --connect-timeout 5 --max-time 30 \
     -o "$tmp_file" \

--- a/system-update-notifier.sh
+++ b/system-update-notifier.sh
@@ -92,7 +92,8 @@ auto_update() {
 
   local script_name
   script_name="$(basename "${BASH_SOURCE[0]}")"
-  local tmp_file="/tmp/${script_name}.new"
+  local tmp_file
+  tmp_file=$(mktemp "/tmp/${script_name}.XXXXXX")
 
   if curl -sL --connect-timeout 5 --max-time 30 \
     -o "$tmp_file" \
@@ -144,7 +145,10 @@ echo "$UPGRADE_LIST" | tr ' ' '\n' | sed 's/^/    ✓ /' >&2
 
 echo "  🔧 Starting installation..." >&2
 log INFO "Installing system updates..."
-apt-get dist-upgrade -y -o Dpkg::Options::="--force-confold" -o Dpkg::Options::="--force-confdef" 2>&1 | tee /tmp/apt-upgrade.log | grep -E '^(Get|Setting|Processing|done|Unpacking|Setting|upgraded|removed|newly installed|Preparing|^$)' >&2
+apt_log=$(mktemp "/tmp/apt-upgrade.XXXXXX")
+# Ensure the file is deleted when script exits to prevent resource leaks
+trap 'rm -f "$apt_log"' EXIT
+apt-get dist-upgrade -y -o Dpkg::Options::="--force-confold" -o Dpkg::Options::="--force-confdef" 2>&1 | tee "$apt_log" | grep -E '^(Get|Setting|Processing|done|Unpacking|Setting|upgraded|removed|newly installed|Preparing|^$)' >&2
 echo "  ✅ Installation completed" >&2
 
 # Determine if a kernel package was upgraded


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: Shell scripts running with elevated privileges (root) were creating temporary files in `/tmp` using predictable paths (e.g., `/tmp/${script_name}.new`). This is vulnerable to symlink attacks, allowing local privilege escalation or arbitrary file overwrites.
🎯 Impact: A local attacker could create a symbolic link at the predictable path pointing to a critical system file. When the script runs as root and writes to the temporary file, it would overwrite the targeted critical file.
🔧 Fix: Replaced predictable temporary file paths with securely generated ones using `mktemp` (e.g., `mktemp "/tmp/script.XXXXXX"`). Also added an `EXIT` trap to ensure temporary files are properly deleted when the script finishes.
✅ Verification: Review the code to ensure all instances of `/tmp/...` for temporary files are now generated by `mktemp`. Run `bash -n` on all modified scripts to verify syntax.

---
*PR created automatically by Jules for task [13618182363719189049](https://jules.google.com/task/13618182363719189049) started by @spupuz*