### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix privilege escalation via predictable /tmp path

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-05-24 - Predictable /tmp Directory Usage Vulnerability
+**Vulnerability:** The script `lxc-updater.sh` was using `mkdir -p /tmp/bin` when trying to bypass interactive prompts in LXC containers. This created a highly predictable temporary directory in a world-writable location. Since these commands run as root, an attacker could pre-create this directory or place malicious scripts (like `clear` or `whiptail`) there, leading to privilege escalation.
+**Learning:** Hardcoding generic paths like `/tmp/bin` for temporary execution environments is dangerous, especially in automated systems running as root. Symlink attacks or pre-staging can allow arbitrary code execution.
+**Prevention:** Always use `mktemp -d` to generate unique, unpredictable temporary directories when executing shell commands. Ensure proper cleanup using a `trap` on `EXIT`.

--- a/lxc-updater.sh
+++ b/lxc-updater.sh
@@ -24,7 +24,7 @@
 
 set -Eeuo pipefail
 
-SCRIPT_VERSION="v0.1.0"
+SCRIPT_VERSION="v0.1.1"
 
 # --- CONFIGURATION ---
 TOKEN=""
@@ -223,7 +223,8 @@ update_lxc() {
       echo "    🔄 Running app update via $candidate..." >&2
       # Create dummy 'clear' and 'whiptail' commands to bypass interactive menus and preventing crashes
       # Whiptail dummy will always echo '2' (Verbose Mode) as its answer
-      if run_in_ct "$ctid" "mkdir -p /tmp/bin; printf '#!/bin/sh\nexit 0' > /tmp/bin/clear; printf '#!/bin/sh\necho 2; exit 0' > /tmp/bin/whiptail; chmod +x /tmp/bin/clear /tmp/bin/whiptail; export PATH=/tmp/bin:\$PATH; export TERM=dumb; export DEBIAN_FRONTEND=noninteractive; export RD=1; export verbose=1; export var_verbose=yes; export var_unattended=yes; $candidate" >&2; then
+      # We use a secure temporary directory to prevent privilege escalation via predictable /tmp path
+      if run_in_ct "$ctid" "tmp_bin=\$(mktemp -d /tmp/bin.XXXXXX) || exit 1; trap 'rm -rf \"\$tmp_bin\"' EXIT; printf '#!/bin/sh\nexit 0' > \"\$tmp_bin/clear\"; printf '#!/bin/sh\necho 2; exit 0' > \"\$tmp_bin/whiptail\"; chmod +x \"\$tmp_bin/clear\" \"\$tmp_bin/whiptail\"; export PATH=\"\$tmp_bin:\$PATH\"; export TERM=dumb; export DEBIAN_FRONTEND=noninteractive; export RD=1; export verbose=1; export var_verbose=yes; export var_unattended=yes; $candidate" >&2; then
         app_updated="yes"
         log INFO "  -> App update completed successfully"
         break

--- a/pve-update-notifier.sh
+++ b/pve-update-notifier.sh
@@ -14,7 +14,7 @@
 # Use this script at your own risk. The authors are not responsible for any
 # data loss, system instability, or service downtime caused by running it.
 
-SCRIPT_VERSION="v0.1.0"
+SCRIPT_VERSION="v0.1.1"
 
 # Add this path variable so Cron can find the required system commands
 export PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"

--- a/system-update-notifier.sh
+++ b/system-update-notifier.sh
@@ -2,7 +2,7 @@
 # System Update Notifier
 # Updates the host system via apt and sends a Telegram notification.
 
-SCRIPT_VERSION="v0.1.0"
+SCRIPT_VERSION="v0.1.1"
 
 export PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** The `lxc-updater.sh` script used a hardcoded, highly predictable temporary directory (`/tmp/bin`) when attempting to bypass interactive prompts in LXC containers. Because these scripts run as root, an attacker or low-privileged user could pre-create this directory or place malicious scripts (e.g., `clear` or `whiptail`) within it, leading to a local privilege escalation (LPE) vulnerability.
🎯 **Impact:** Potential arbitrary code execution as root inside the LXC container.
🔧 **Fix:** Replaced the predictable `mkdir -p /tmp/bin` with a secure randomized temporary directory generation using `mktemp -d`. Added a `trap` to ensure proper cleanup upon exit. Bumped `SCRIPT_VERSION` in all three primary scripts as per standard guidelines.
✅ **Verification:** Verified that `bash -n` passes for all scripts. Checked that the new `run_in_ct` command creates, uses, and cleans up the temporary directory cleanly.

---
*PR created automatically by Jules for task [328903121664537807](https://jules.google.com/task/328903121664537807) started by @spupuz*