### PR TITLE
🎨 Palette: Add actionable Telegram config error messages

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,3 +1,7 @@
 ## 2024-05-24 - [UX Polish] Added Actionable Error Messages and English Translations
 **Learning:** Language inconsistencies and generic errors create friction in CLI/Bot UX.
 **Action:** Ensure all bot notifications use English consistently and add clear (e.g., 'Try using sudo') actionable paths to error messages.
+
+## 2026-07-23 - [Actionable CLI Error Messages]
+**Learning:** Generic error messages (like 'Telegram config missing') leave users stuck without a clear path to resolution, creating a poor developer experience.
+**Action:** Always provide actionable resolution steps in CLI error messages (e.g., specifying exact file paths or environment variables to check).

--- a/lxc-updater.sh
+++ b/lxc-updater.sh
@@ -24,7 +24,7 @@
 
 set -Eeuo pipefail
 
-SCRIPT_VERSION="v0.2.0"
+SCRIPT_VERSION="v0.2.1"
 
 # --- CONFIGURATION ---
 TOKEN=""
@@ -87,7 +87,7 @@ log() {
 
 send_telegram() {
     local message="$1"
-    [[ -z "${TOKEN}" || -z "${CHAT_ID}" ]] && { log WARN "Telegram config missing, skipping notification."; return 0; }
+    [[ -z "${TOKEN}" || -z "${CHAT_ID}" ]] && { log WARN "Telegram config missing, skipping notification. Please set TOKEN and CHAT_ID in telegram.conf or /etc/pve-telegram.conf"; return 0; }
 
     log INFO "Sending report to Telegram..."
     local URL="https://api.telegram.org/bot${TOKEN}/sendMessage"

--- a/pve-update-notifier.sh
+++ b/pve-update-notifier.sh
@@ -14,7 +14,7 @@
 # Use this script at your own risk. The authors are not responsible for any
 # data loss, system instability, or service downtime caused by running it.
 
-SCRIPT_VERSION="v0.2.0"
+SCRIPT_VERSION="v0.2.1"
 
 # Add this path variable so Cron can find the required system commands
 export PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
@@ -60,7 +60,7 @@ HOSTNAME="${HOSTNAME:-$(hostname -f 2>/dev/null || hostname)}"
 # --- TELEGRAM FUNCTION ---
 send_telegram() {
     local message="$1"
-    [[ -z "${TOKEN}" || -z "${CHAT_ID}" ]] && { log WARN "Telegram config missing, skipping notification."; return 0; }
+    [[ -z "${TOKEN}" || -z "${CHAT_ID}" ]] && { log WARN "Telegram config missing, skipping notification. Please set TOKEN and CHAT_ID in telegram.conf or /etc/pve-telegram.conf"; return 0; }
 
     local URL="https://api.telegram.org/bot${TOKEN}/sendMessage"
 

--- a/system-update-notifier.sh
+++ b/system-update-notifier.sh
@@ -2,7 +2,7 @@
 # System Update Notifier
 # Updates the host system via apt and sends a Telegram notification.
 
-SCRIPT_VERSION="v0.2.0"
+SCRIPT_VERSION="v0.2.1"
 
 export PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 
@@ -31,7 +31,7 @@ TOKEN="${TOKEN:-}"; CHAT_ID="${CHAT_ID:-}"; HOSTNAME="${HOSTNAME:-$(hostname -f 
 # --- TELEGRAM SEND ---
 send_telegram(){
   local message="$1"
-  [[ -z "$TOKEN" || -z "$CHAT_ID" ]] && { log WARN "Telegram config missing"; return 0; }
+  [[ -z "$TOKEN" || -z "$CHAT_ID" ]] && { log WARN "Telegram config missing, skipping notification. Please set TOKEN and CHAT_ID in telegram.conf or /etc/pve-telegram.conf"; return 0; }
   local URL="https://api.telegram.org/bot${TOKEN}/sendMessage"
   local RESPONSE=$(curl -s -X POST "$URL" \
     --data-urlencode "chat_id=$CHAT_ID" \


### PR DESCRIPTION
💡 What: Made 'Telegram config missing' error messages actionable by specifying where to define the configuration.
🎯 Why: Generic error messages leave users stuck. Providing the exact file path (`telegram.conf` or `/etc/pve-telegram.conf`) helps users quickly resolve the issue.
♿ Accessibility: Improves CLI usability and reduces friction for new users setting up the scripts.

Also bumped `SCRIPT_VERSION` to `v0.2.1` across all scripts as per repository conventions.

---
*PR created automatically by Jules for task [16005986524409859136](https://jules.google.com/task/16005986524409859136) started by @spupuz*