### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix command injection in version comparison

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -2,3 +2,8 @@
 **Vulnerability:** The script `lxc-updater.sh` was using `mkdir -p /tmp/bin` when trying to bypass interactive prompts in LXC containers. This created a highly predictable temporary directory in a world-writable location. Since these commands run as root, an attacker could pre-create this directory or place malicious scripts (like `clear` or `whiptail`) there, leading to privilege escalation.
 **Learning:** Hardcoding generic paths like `/tmp/bin` for temporary execution environments is dangerous, especially in automated systems running as root. Symlink attacks or pre-staging can allow arbitrary code execution.
 **Prevention:** Always use `mktemp -d` to generate unique, unpredictable temporary directories when executing shell commands. Ensure proper cleanup using a `trap` on `EXIT`.
+
+## 2026-07-23 - Command Injection in Version Comparison
+**Vulnerability:** The `version_compare` function used string extraction from `vMAJOR.MINOR.PATCH` and directly evaluated the variables in bash arithmetic operations like `(( major1 > major2 ))`. If an attacker manipulates the latest tag returned by the GitHub API to include command injection payloads (e.g., `v1.2[$(malicious_command)]`), it gets executed when the `(( ... ))` evaluates the payload.
+**Learning:** Bash arithmetic evaluation `(( ... ))` natively evaluates variables containing arrays and execution constructs even if they aren't explicitly prefixed with `$`. Using unvalidated strings from an external source (like a GitHub API call) in arithmetic evaluation is a vector for Remote Code Execution.
+**Prevention:** Always strip non-numeric characters from version components (e.g., `major1=${major1//[^0-9]/}`) before utilizing them in arithmetic evaluations to prevent injection.

--- a/lxc-updater.sh
+++ b/lxc-updater.sh
@@ -24,7 +24,7 @@
 
 set -Eeuo pipefail
 
-SCRIPT_VERSION="v0.2.0"
+SCRIPT_VERSION="v0.2.1"
 
 # --- CONFIGURATION ---
 TOKEN=""
@@ -111,6 +111,11 @@ version_compare() {
   local IFS=.
   read -r major1 minor1 patch1 <<< "$v1"
   read -r major2 minor2 patch2 <<< "$v2"
+
+  # Strip non-numeric characters to prevent arbitrary code execution in arithmetic evaluation
+  major1=${major1//[^0-9]/}; minor1=${minor1//[^0-9]/}; patch1=${patch1//[^0-9]/}
+  major2=${major2//[^0-9]/}; minor2=${minor2//[^0-9]/}; patch2=${patch2//[^0-9]/}
+
   major1=${major1:-0}; minor1=${minor1:-0}; patch1=${patch1:-0}
   major2=${major2:-0}; minor2=${minor2:-0}; patch2=${patch2:-0}
 

--- a/pve-update-notifier.sh
+++ b/pve-update-notifier.sh
@@ -14,7 +14,7 @@
 # Use this script at your own risk. The authors are not responsible for any
 # data loss, system instability, or service downtime caused by running it.
 
-SCRIPT_VERSION="v0.2.0"
+SCRIPT_VERSION="v0.2.1"
 
 # Add this path variable so Cron can find the required system commands
 export PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
@@ -83,6 +83,11 @@ version_compare() {
   local IFS=.
   read -r major1 minor1 patch1 <<< "$v1"
   read -r major2 minor2 patch2 <<< "$v2"
+
+  # Strip non-numeric characters to prevent arbitrary code execution in arithmetic evaluation
+  major1=${major1//[^0-9]/}; minor1=${minor1//[^0-9]/}; patch1=${patch1//[^0-9]/}
+  major2=${major2//[^0-9]/}; minor2=${minor2//[^0-9]/}; patch2=${patch2//[^0-9]/}
+
   major1=${major1:-0}; minor1=${minor1:-0}; patch1=${patch1:-0}
   major2=${major2:-0}; minor2=${minor2:-0}; patch2=${patch2:-0}
 

--- a/system-update-notifier.sh
+++ b/system-update-notifier.sh
@@ -2,7 +2,7 @@
 # System Update Notifier
 # Updates the host system via apt and sends a Telegram notification.
 
-SCRIPT_VERSION="v0.2.0"
+SCRIPT_VERSION="v0.2.1"
 
 export PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 
@@ -46,6 +46,11 @@ version_compare() {
   local IFS=.
   read -r major1 minor1 patch1 <<< "$v1"
   read -r major2 minor2 patch2 <<< "$v2"
+
+  # Strip non-numeric characters to prevent arbitrary code execution in arithmetic evaluation
+  major1=${major1//[^0-9]/}; minor1=${minor1//[^0-9]/}; patch1=${patch1//[^0-9]/}
+  major2=${major2//[^0-9]/}; minor2=${minor2//[^0-9]/}; patch2=${patch2//[^0-9]/}
+
   major1=${major1:-0}; minor1=${minor1:-0}; patch1=${patch1:-0}
   major2=${major2:-0}; minor2=${minor2:-0}; patch2=${patch2:-0}
 


### PR DESCRIPTION
🚨 **Severity**: CRITICAL
💡 **Vulnerability**: The `version_compare` function used string extraction from `vMAJOR.MINOR.PATCH` and directly evaluated the variables in bash arithmetic operations. If an attacker manipulates the latest tag returned by the GitHub API to include command injection payloads, it gets executed when the arithmetic evaluation occurs.
🎯 **Impact**: Remote Code Execution (RCE) on the Proxmox host if the upstream GitHub response is compromised or manipulated.
🔧 **Fix**: Added logic to strip all non-numeric characters from version component strings (major, minor, patch) before allowing them to be processed by bash arithmetic evaluation contexts (`(( ... ))`).
✅ **Verification**: Code syntactically validated using `bash -n`. Security journal updated with details on how to prevent this vulnerability. Version tags bumped synchronously across all modified scripts.

---
*PR created automatically by Jules for task [1309389332587098193](https://jules.google.com/task/1309389332587098193) started by @spupuz*