### PR TITLE
⚡ Bolt: Optimize auto-update network requests

### DIFF
--- a/lxc-updater.sh
+++ b/lxc-updater.sh
@@ -24,7 +24,7 @@
 
 set -Eeuo pipefail
 
-SCRIPT_VERSION="v0.4.0"
+SCRIPT_VERSION="v0.4.1"
 
 # --- CONFIGURATION ---
 TOKEN=""
@@ -134,18 +134,16 @@ auto_update() {
   local force="${1:-no}"
   [[ "${force}" == "no" && "${AUTO_UPDATE:-no}" == "no" ]] && return 0
 
-  if ! curl -s --connect-timeout 5 --max-time 10 "https://api.github.com" >/dev/null 2>&1; then
-    log INFO "GitHub not reachable, proceeding with current version ($SCRIPT_VERSION)"
-    return 0
-  fi
-
   local latest_tag
+  # ⚡ Bolt: Removed redundant connectivity check to GitHub API
+  # Impact: Halves the number of network requests and avoids extra latency
+  # by attempting the fetch directly and handling failure gracefully.
   latest_tag=$(curl -s --connect-timeout 5 --max-time 10 \
     "https://api.github.com/repos/spupuz/proxmox-scripts/releases/latest" \
     | grep '"tag_name"' | head -1 | sed 's/.*"tag_name": *"//;s/".*//')
 
   if [[ -z "$latest_tag" ]]; then
-    log WARN "Could not determine latest version from GitHub"
+    log INFO "Could not determine latest version from GitHub (or GitHub not reachable), proceeding with current version ($SCRIPT_VERSION)"
     return 0
   fi
 

--- a/pve-update-notifier.sh
+++ b/pve-update-notifier.sh
@@ -14,7 +14,7 @@
 # Use this script at your own risk. The authors are not responsible for any
 # data loss, system instability, or service downtime caused by running it.
 
-SCRIPT_VERSION="v0.4.0"
+SCRIPT_VERSION="v0.4.1"
 
 # Add this path variable so Cron can find the required system commands
 export PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
@@ -105,18 +105,16 @@ auto_update() {
   local force="${1:-no}"
   [[ "${force}" == "no" && "${AUTO_UPDATE:-no}" == "no" ]] && return 0
 
-  if ! curl -s --connect-timeout 5 --max-time 10 "https://api.github.com" >/dev/null 2>&1; then
-    log INFO "GitHub not reachable, proceeding with current version ($SCRIPT_VERSION)"
-    return 0
-  fi
-
   local latest_tag
+  # ⚡ Bolt: Removed redundant connectivity check to GitHub API
+  # Impact: Halves the number of network requests and avoids extra latency
+  # by attempting the fetch directly and handling failure gracefully.
   latest_tag=$(curl -s --connect-timeout 5 --max-time 10 \
     "https://api.github.com/repos/spupuz/proxmox-scripts/releases/latest" \
     | grep '"tag_name"' | head -1 | sed 's/.*"tag_name": *"//;s/".*//')
 
   if [[ -z "$latest_tag" ]]; then
-    log WARN "Could not determine latest version from GitHub"
+    log INFO "Could not determine latest version from GitHub (or GitHub not reachable), proceeding with current version ($SCRIPT_VERSION)"
     return 0
   fi
 

--- a/system-update-notifier.sh
+++ b/system-update-notifier.sh
@@ -2,7 +2,7 @@
 # System Update Notifier
 # Updates the host system via apt and sends a Telegram notification.
 
-SCRIPT_VERSION="v0.4.0"
+SCRIPT_VERSION="v0.4.1"
 
 export PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 
@@ -68,18 +68,16 @@ auto_update() {
   local force="${1:-no}"
   [[ "${force}" == "no" && "${AUTO_UPDATE:-no}" == "no" ]] && return 0
 
-  if ! curl -s --connect-timeout 5 --max-time 10 "https://api.github.com" >/dev/null 2>&1; then
-    log INFO "GitHub not reachable, proceeding with current version ($SCRIPT_VERSION)"
-    return 0
-  fi
-
   local latest_tag
+  # ⚡ Bolt: Removed redundant connectivity check to GitHub API
+  # Impact: Halves the number of network requests and avoids extra latency
+  # by attempting the fetch directly and handling failure gracefully.
   latest_tag=$(curl -s --connect-timeout 5 --max-time 10 \
     "https://api.github.com/repos/spupuz/proxmox-scripts/releases/latest" \
     | grep '"tag_name"' | head -1 | sed 's/.*"tag_name": *"//;s/".*//')
 
   if [[ -z "$latest_tag" ]]; then
-    log WARN "Could not determine latest version from GitHub"
+    log INFO "Could not determine latest version from GitHub (or GitHub not reachable), proceeding with current version ($SCRIPT_VERSION)"
     return 0
   fi
 


### PR DESCRIPTION
💡 What: Removed a redundant connectivity check (`curl` to GitHub API) in the `auto_update` function across all three bash scripts, combining it into the main fetch request. Updated script versions to v0.4.1.

🎯 Why: The previous "ping-then-fetch" pattern doubled the amount of GitHub API rate limit usage and added unnecessary network latency, which is inefficient for cron-based scripts that might run on multiple nodes.

📊 Impact: Halves the number of network requests made during the auto-update check and eliminates the latency of the extra connection setup.

🔬 Measurement: Reviewing the script execution logs (and network traffic, if monitored) will show only 1 outbound connection to api.github.com instead of 2. Validated with `bash -n` to ensure no syntax errors were introduced.

---
*PR created automatically by Jules for task [14606707047502197320](https://jules.google.com/task/14606707047502197320) started by @spupuz*