### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Path Traversal in Auto-Updater API Response Parsing

### DIFF
--- a/lxc-updater.sh
+++ b/lxc-updater.sh
@@ -24,7 +24,7 @@
 
 set -Eeuo pipefail
 
-SCRIPT_VERSION="v0.4.0"
+SCRIPT_VERSION="v0.4.1"
 
 # --- CONFIGURATION ---
 TOKEN=""
@@ -146,6 +146,12 @@ auto_update() {
 
   if [[ -z "$latest_tag" ]]; then
     log WARN "Could not determine latest version from GitHub"
+    return 0
+  fi
+
+  # 🛡️ Sentinel: Validate tag format to prevent path traversal via malicious GitHub API response
+  if [[ ! "$latest_tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    log ERROR "Invalid version tag format received from GitHub: $latest_tag"
     return 0
   fi
 

--- a/pve-update-notifier.sh
+++ b/pve-update-notifier.sh
@@ -14,7 +14,7 @@
 # Use this script at your own risk. The authors are not responsible for any
 # data loss, system instability, or service downtime caused by running it.
 
-SCRIPT_VERSION="v0.4.0"
+SCRIPT_VERSION="v0.4.1"
 
 # Add this path variable so Cron can find the required system commands
 export PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
@@ -117,6 +117,12 @@ auto_update() {
 
   if [[ -z "$latest_tag" ]]; then
     log WARN "Could not determine latest version from GitHub"
+    return 0
+  fi
+
+  # 🛡️ Sentinel: Validate tag format to prevent path traversal via malicious GitHub API response
+  if [[ ! "$latest_tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    log ERROR "Invalid version tag format received from GitHub: $latest_tag"
     return 0
   fi
 

--- a/system-update-notifier.sh
+++ b/system-update-notifier.sh
@@ -2,7 +2,7 @@
 # System Update Notifier
 # Updates the host system via apt and sends a Telegram notification.
 
-SCRIPT_VERSION="v0.4.0"
+SCRIPT_VERSION="v0.4.1"
 
 export PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 
@@ -80,6 +80,12 @@ auto_update() {
 
   if [[ -z "$latest_tag" ]]; then
     log WARN "Could not determine latest version from GitHub"
+    return 0
+  fi
+
+  # 🛡️ Sentinel: Validate tag format to prevent path traversal via malicious GitHub API response
+  if [[ ! "$latest_tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+    log ERROR "Invalid version tag format received from GitHub: $latest_tag"
     return 0
   fi
 


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The `auto_update` mechanism relied on the GitHub API's `latest_tag` without validation when constructing download URLs (e.g., `https://raw.githubusercontent.com/.../${latest_tag}/${script_name}`). A spoofed or manipulated API response containing a path traversal sequence (e.g., `1.0/../../../../eviluser/evilrepo/main`) could cause the script to download and execute arbitrary malicious code.
🎯 Impact: Remote Code Execution (RCE) via path traversal if the GitHub API was spoofed, compromised, or subject to a Man-in-the-Middle attack.
🔧 Fix: Added strict regex validation (`^v[0-9]+\.[0-9]+\.[0-9]+$`) to the `latest_tag` variable in all three updater scripts (`lxc-updater.sh`, `pve-update-notifier.sh`, `system-update-notifier.sh`) to ensure the tag is a safe semantic version before proceeding. Added a log entry in `.jules/sentinel.md` documenting the vulnerability. Bumped `SCRIPT_VERSION` to `v0.4.1` in all scripts.
✅ Verification: Tested script syntax with `bash -n`. Verified that the regex correctly rejects strings containing slashes.

---
*PR created automatically by Jules for task [18126401831026144364](https://jules.google.com/task/18126401831026144364) started by @spupuz*