### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Credential Leakage in process list via curl arguments

### DIFF
--- a/lxc-updater.sh
+++ b/lxc-updater.sh
@@ -24,7 +24,7 @@
 
 set -Eeuo pipefail
 
-SCRIPT_VERSION="v0.5.1"
+SCRIPT_VERSION="v0.5.2"
 
 # --- CONFIGURATION ---
 TOKEN=""
@@ -94,7 +94,9 @@ send_telegram() {
     log INFO "Sending report to Telegram..."
     local URL="https://api.telegram.org/bot${TOKEN}/sendMessage"
 
-    RESPONSE=$(curl -s -X POST "$URL" \
+    # 🛡️ Sentinel Security Fix: Prevent TOKEN leakage in process list (ps aux).
+    # Pass URL with token via stdin to curl using -K to hide it from command line arguments.
+    RESPONSE=$(echo "url = \"$URL\"" | curl -s -K - -X POST \
         --data-urlencode "chat_id=$CHAT_ID" \
         --data-urlencode "parse_mode=Markdown" \
         --data-urlencode "text=$message")

--- a/pve-update-notifier.sh
+++ b/pve-update-notifier.sh
@@ -14,7 +14,7 @@
 # Use this script at your own risk. The authors are not responsible for any
 # data loss, system instability, or service downtime caused by running it.
 
-SCRIPT_VERSION="v0.5.1"
+SCRIPT_VERSION="v0.5.2"
 
 # Add this path variable so Cron can find the required system commands
 export PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
@@ -65,7 +65,9 @@ send_telegram() {
 
     local URL="https://api.telegram.org/bot${TOKEN}/sendMessage"
 
-    RESPONSE=$(curl -s -X POST "$URL" \
+    # 🛡️ Sentinel Security Fix: Prevent TOKEN leakage in process list (ps aux).
+    # Pass URL with token via stdin to curl using -K to hide it from command line arguments.
+    RESPONSE=$(echo "url = \"$URL\"" | curl -s -K - -X POST \
         --data-urlencode "chat_id=$CHAT_ID" \
         --data-urlencode "parse_mode=Markdown" \
         --data-urlencode "text=$message")

--- a/system-update-notifier.sh
+++ b/system-update-notifier.sh
@@ -2,7 +2,7 @@
 # System Update Notifier
 # Updates the host system via apt and sends a Telegram notification.
 
-SCRIPT_VERSION="v0.5.1"
+SCRIPT_VERSION="v0.5.2"
 
 export PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 
@@ -34,7 +34,9 @@ send_telegram(){
   local message="$1"
   [[ -z "$TOKEN" || -z "$CHAT_ID" ]] && { log WARN "Telegram config missing, skipping notification. Please set TOKEN and CHAT_ID in telegram.conf or /etc/pve-telegram.conf"; return 0; }
   local URL="https://api.telegram.org/bot${TOKEN}/sendMessage"
-  local RESPONSE=$(curl -s -X POST "$URL" \
+  # 🛡️ Sentinel Security Fix: Prevent TOKEN leakage in process list (ps aux).
+  # Pass URL with token via stdin to curl using -K to hide it from command line arguments.
+  local RESPONSE=$(echo "url = \"$URL\"" | curl -s -K - -X POST \
     --data-urlencode "chat_id=$CHAT_ID" \
     --data-urlencode "parse_mode=Markdown" \
     --data-urlencode "text=$message")


### PR DESCRIPTION
- Fixed a security issue where the Telegram bot `$TOKEN` was exposed in the system process list because it was passed as a command-line argument to `curl`.
- Changed `send_telegram` functions in `lxc-updater.sh`, `pve-update-notifier.sh`, and `system-update-notifier.sh` to use `echo "url = \"$URL\"" | curl -K -` to securely pass the token via standard input.
- Bumped `SCRIPT_VERSION` to `v0.5.2` in all three scripts as required by the `AGENTS.md` file.
- Added a new entry to the Sentinel journal (`.jules/sentinel.md`) documenting this specific security risk and the `curl -K` prevention strategy.
- Verified bash syntax for all updated scripts.

---
*PR created automatically by Jules for task [14786958188530910446](https://jules.google.com/task/14786958188530910446) started by @spupuz*