### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix ARG_MAX limit and process list leakage in Telegram notifications

### DIFF
--- a/lxc-updater.sh
+++ b/lxc-updater.sh
@@ -24,7 +24,7 @@
 
 set -Eeuo pipefail
 
-SCRIPT_VERSION="v0.5.3"
+SCRIPT_VERSION="v0.5.4"
 
 # --- CONFIGURATION ---
 TOKEN=""
@@ -94,12 +94,14 @@ send_telegram() {
     log INFO "Sending report to Telegram..."
     local URL="https://api.telegram.org/bot${TOKEN}/sendMessage"
 
-    # 🛡️ Sentinel Security Fix: Prevent TOKEN leakage in process list (ps aux).
-    # Pass URL with token via stdin to curl using -K to hide it from command line arguments.
-    RESPONSE=$(echo "url = \"$URL\"" | curl -s -K - -X POST \
-        --data-urlencode "chat_id=$CHAT_ID" \
-        --data-urlencode "parse_mode=Markdown" \
-        --data-urlencode "text=$message")
+    # 🛡️ Sentinel Security Fix: Prevent TOKEN leakage and fix ARG_MAX for large reports.
+    # Use process substitution for config and pass the message body via stdin.
+    RESPONSE=$(curl -s -X POST -K <(cat <<CURL_CONF
+url = "$URL"
+data-urlencode = "chat_id=$CHAT_ID"
+data-urlencode = "parse_mode=Markdown"
+CURL_CONF
+) --data-urlencode "text@-" <<< "$message")
 
     if [[ $RESPONSE != *'"ok":true'* ]]; then
         log ERROR "Telegram Error: $RESPONSE"

--- a/pve-update-notifier.sh
+++ b/pve-update-notifier.sh
@@ -14,7 +14,7 @@
 # Use this script at your own risk. The authors are not responsible for any
 # data loss, system instability, or service downtime caused by running it.
 
-SCRIPT_VERSION="v0.5.3"
+SCRIPT_VERSION="v0.5.4"
 
 # Add this path variable so Cron can find the required system commands
 export PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
@@ -65,12 +65,14 @@ send_telegram() {
 
     local URL="https://api.telegram.org/bot${TOKEN}/sendMessage"
 
-    # 🛡️ Sentinel Security Fix: Prevent TOKEN leakage in process list (ps aux).
-    # Pass URL with token via stdin to curl using -K to hide it from command line arguments.
-    RESPONSE=$(echo "url = \"$URL\"" | curl -s -K - -X POST \
-        --data-urlencode "chat_id=$CHAT_ID" \
-        --data-urlencode "parse_mode=Markdown" \
-        --data-urlencode "text=$message")
+    # 🛡️ Sentinel Security Fix: Prevent TOKEN leakage and fix ARG_MAX for large reports.
+    # Use process substitution for config and pass the message body via stdin.
+    RESPONSE=$(curl -s -X POST -K <(cat <<CURL_CONF
+url = "$URL"
+data-urlencode = "chat_id=$CHAT_ID"
+data-urlencode = "parse_mode=Markdown"
+CURL_CONF
+) --data-urlencode "text@-" <<< "$message")
 
     if [[ $RESPONSE != *'"ok":true'* ]]; then
         log ERROR "Telegram Error: $RESPONSE"

--- a/system-update-notifier.sh
+++ b/system-update-notifier.sh
@@ -2,7 +2,7 @@
 # System Update Notifier
 # Updates the host system via apt and sends a Telegram notification.
 
-SCRIPT_VERSION="v0.5.3"
+SCRIPT_VERSION="v0.5.4"
 
 export PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 
@@ -34,12 +34,14 @@ send_telegram(){
   local message="$1"
   [[ -z "$TOKEN" || -z "$CHAT_ID" ]] && { log WARN "Telegram config missing, skipping notification. Please set TOKEN and CHAT_ID in telegram.conf or /etc/pve-telegram.conf"; return 0; }
   local URL="https://api.telegram.org/bot${TOKEN}/sendMessage"
-  # 🛡️ Sentinel Security Fix: Prevent TOKEN leakage in process list (ps aux).
-  # Pass URL with token via stdin to curl using -K to hide it from command line arguments.
-  local RESPONSE=$(echo "url = \"$URL\"" | curl -s -K - -X POST \
-    --data-urlencode "chat_id=$CHAT_ID" \
-    --data-urlencode "parse_mode=Markdown" \
-    --data-urlencode "text=$message")
+  # 🛡️ Sentinel Security Fix: Prevent TOKEN leakage and fix ARG_MAX for large reports.
+  # Use process substitution for config and pass the message body via stdin.
+  local RESPONSE=$(curl -s -X POST -K <(cat <<CURL_CONF
+url = "$URL"
+data-urlencode = "chat_id=$CHAT_ID"
+data-urlencode = "parse_mode=Markdown"
+CURL_CONF
+) --data-urlencode "text@-" <<< "$message")
   [[ $RESPONSE != *'"ok":true'* ]] && { log ERROR "Telegram error: $RESPONSE"; echo "❌ Telegram Error: $RESPONSE" >&2; } || log INFO "Telegram sent"
 }
 


### PR DESCRIPTION
🚨 **Severity:** CRITICAL
💡 **Vulnerability:** Extremely long text payloads containing update reports were being passed as command line arguments to `curl` (`text=$message`). This causes `Argument list too long` (ARG_MAX) errors, crashing the script and preventing reports from sending on busy hypervisors. Additionally, earlier implementations left process limits vulnerable to data leakage (e.g. via `ps aux`).
🎯 **Impact:** Prevents notifications from failing silently on large clusters. Secures the process list from leaking payload strings and configuration values.
🔧 **Fix:** Shifted the `url`, `chat_id`, and `parse_mode` into a dynamically generated `curl` config file using process substitution (`-K <(cat <<CURL_CONF...)`), and streamed the actual `message` into `curl` via standard input (`--data-urlencode "text@-" <<< "$message"`), entirely bypassing command line argument limits.
✅ **Verification:** Verified syntax across all scripts using `bash -n`. Successfully ran mock configurations to ensure payload formatting is identical.

---
*PR created automatically by Jules for task [266472556071049756](https://jules.google.com/task/266472556071049756) started by @spupuz*