### PR TITLE
🛡️ Sentinel: [HIGH] Fix un-sanitized output in Telegram notifications

### DIFF
--- a/lxc-updater.sh
+++ b/lxc-updater.sh
@@ -24,7 +24,7 @@
 
 set -Eeuo pipefail
 
-SCRIPT_VERSION="v0.5.4"
+SCRIPT_VERSION="v0.5.5"
 
 # --- CONFIGURATION ---
 TOKEN=""
@@ -427,7 +427,7 @@ main() {
   if [[ "$host_upd" == "error" ]]; then
     report+="🖥️ *Proxmox Host*: ❌ Error during check"$'\n'
   elif [[ -n "$host_upd_clean" ]] && [[ "$host_upd_clean" -gt 0 ]]; then
-    report+="🖥️ *Proxmox Host*: ⚠️ $host_upd updates available (not installed)"$'\n'
+    report+="🖥️ *Proxmox Host*: ⚠️ $host_upd_clean updates available (not installed)"$'\n'
   else
     report+="🖥️ *Proxmox Host*: ✅ System is up to date"$'\n'
   fi

--- a/pve-update-notifier.sh
+++ b/pve-update-notifier.sh
@@ -14,7 +14,7 @@
 # Use this script at your own risk. The authors are not responsible for any
 # data loss, system instability, or service downtime caused by running it.
 
-SCRIPT_VERSION="v0.5.4"
+SCRIPT_VERSION="v0.5.5"
 
 # Add this path variable so Cron can find the required system commands
 export PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
@@ -226,7 +226,7 @@ HOST_UPDATES_CLEAN="${HOST_UPDATES//[^0-9]/}"
 if [ -z "$HOST_UPDATES_CLEAN" ] || [ "$HOST_UPDATES_CLEAN" -eq 0 ]; then
     REPORT+="🖥️ *Proxmox Host*: ✅ Up to date"$'\n'
 else
-    REPORT+="🖥️ *Proxmox Host*: ⚠️ $HOST_UPDATES updates available"$'\n'
+    REPORT+="🖥️ *Proxmox Host*: ⚠️ $HOST_UPDATES_CLEAN updates available"$'\n'
 fi
 
 if $IS_PVE_HOST; then
@@ -263,7 +263,7 @@ if $IS_PVE_HOST; then
           elif [ "$LXC_UPD_RESULT" = "ERROR" ]; then
               REPORT+="• ID $CTID ($CTNAME): ❌ Error checking updates"$'\n'
            elif [ ! -z "$LXC_UPD_RESULT_CLEAN" ] && [ "$LXC_UPD_RESULT_CLEAN" -gt 0 ] 2>/dev/null; then
-              REPORT+="• ID $CTID ($CTNAME): ⚠️ *$LXC_UPD_RESULT* updates available"$'\n'
+              REPORT+="• ID $CTID ($CTNAME): ⚠️ *$LXC_UPD_RESULT_CLEAN* updates available"$'\n'
           else
               REPORT+="• ID $CTID ($CTNAME): ✅ Up to date"$'\n'
           fi

--- a/system-update-notifier.sh
+++ b/system-update-notifier.sh
@@ -2,7 +2,7 @@
 # System Update Notifier
 # Updates the host system via apt and sends a Telegram notification.
 
-SCRIPT_VERSION="v0.5.4"
+SCRIPT_VERSION="v0.5.5"
 
 export PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 


### PR DESCRIPTION
🛡️ Sentinel: [HIGH] Fix un-sanitized output in Telegram notifications

This PR fixes a vulnerability where unsanitized outputs from LXC containers (`LXC_UPD_RESULT`) and `apt-get` commands (`HOST_UPDATES`, `host_upd`) were being embedded directly into Telegram Markdown notifications.

While these variables were correctly sanitized for arithmetic evaluation (to prevent command injection) using variables like `HOST_UPDATES_CLEAN` and `LXC_UPD_RESULT_CLEAN`, the original unsanitized variables were mistakenly used during string interpolation for the Telegram report. This could allow for Server-Side Request Forgery (SSRF) / Markdown injection or unexpected formatting in Telegram if the output contained special characters or was manipulated by a compromised container.

This fix ensures the `_clean` versions of the variables are used consistently for message construction as well.

The `SCRIPT_VERSION` was bumped to `v0.5.5` in all scripts per the versioning standard.

---
*PR created automatically by Jules for task [14661061943610478973](https://jules.google.com/task/14661061943610478973) started by @spupuz*