### PR TITLE
🛡️ Sentinel: [HIGH] Fix Markdown injection in Telegram notifications

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,23 @@
+name: Tests
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Run scripts tests
+        run: |
+          for script in scripts/test_*.sh; do
+            if [ -f "$script" ] && [ -x "$script" ]; then
+              echo "Running $script..."
+              "$script"
+            fi
+          done

--- a/lxc-updater.sh
+++ b/lxc-updater.sh
@@ -24,7 +24,7 @@
 
 set -Eeuo pipefail
 
-SCRIPT_VERSION="v0.5.6"
+SCRIPT_VERSION="v0.5.7"
 
 # --- CONFIGURATION ---
 TOKEN=""
@@ -50,6 +50,14 @@ fi
 TOKEN="${TOKEN:-}"
 CHAT_ID="${CHAT_ID:-}"
 HOSTNAME="${HOSTNAME:-$(hostname -f 2>/dev/null || hostname)}"
+
+# 🛡️ Sentinel Security Fix: Escape Markdown control characters to prevent Telegram API injection DoS
+HOSTNAME="${HOSTNAME//_/\\_}"
+HOSTNAME="${HOSTNAME//\*/\\*}"
+HOSTNAME="${HOSTNAME//\[/\\[}"
+HOSTNAME="${HOSTNAME//\]/\\]}"
+HOSTNAME="${HOSTNAME//\`/\\\`}"
+
 EXCLUDED_CTIDS=("${EXCLUDED_CTIDS[@]:-}")
 CLEAN_TMP_7_DAYS="${CLEAN_TMP_7_DAYS:-yes}"
 CT_OPERATION_TIMEOUT="${CT_OPERATION_TIMEOUT:-300}"
@@ -451,6 +459,12 @@ main() {
 
       local ctid="${item%%:*}"
       local ctname="${item##*:}"
+      # 🛡️ Sentinel Security Fix: Escape container name to prevent Markdown injection
+      ctname="${ctname//_/\\_}"
+      ctname="${ctname//\*/\\*}"
+      ctname="${ctname//\[/\\[}"
+      ctname="${ctname//\]/\\]}"
+      ctname="${ctname//\`/\\\`}"
 
       if is_excluded "$ctid"; then
         report+="• ${ctid}: ⏭️ Excluded"$'\n'

--- a/pve-update-notifier.sh
+++ b/pve-update-notifier.sh
@@ -14,7 +14,7 @@
 # Use this script at your own risk. The authors are not responsible for any
 # data loss, system instability, or service downtime caused by running it.
 
-SCRIPT_VERSION="v0.5.6"
+SCRIPT_VERSION="v0.5.7"
 
 # Add this path variable so Cron can find the required system commands
 export PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
@@ -56,6 +56,14 @@ fi
 TOKEN="${TOKEN:-}"
 CHAT_ID="${CHAT_ID:-}"
 HOSTNAME="${HOSTNAME:-$(hostname -f 2>/dev/null || hostname)}"
+
+# 🛡️ Sentinel Security Fix: Escape Markdown control characters to prevent Telegram API injection DoS
+HOSTNAME="${HOSTNAME//_/\\_}"
+HOSTNAME="${HOSTNAME//\*/\\*}"
+HOSTNAME="${HOSTNAME//\[/\\[}"
+HOSTNAME="${HOSTNAME//\]/\\]}"
+HOSTNAME="${HOSTNAME//\`/\\\`}"
+
 AUTO_UPDATE="${AUTO_UPDATE:-no}" # Set to "yes" to enable automatic script updates from GitHub
 
 # --- TELEGRAM FUNCTION ---
@@ -243,6 +251,12 @@ if $IS_PVE_HOST; then
       [[ -z "$item" ]] && continue
       CTID="${item%%:*}"
       CTNAME="${item##*:}"
+      # 🛡️ Sentinel Security Fix: Escape container name to prevent Markdown injection
+      CTNAME="${CTNAME//_/\\_}"
+      CTNAME="${CTNAME//\*/\\*}"
+      CTNAME="${CTNAME//\[/\\[}"
+      CTNAME="${CTNAME//\]/\\]}"
+      CTNAME="${CTNAME//\`/\\\`}"
       log INFO "Checking LXC $CTID ($CTNAME)..."
 
           LXC_UPD_RESULT=$(timeout 60 pct exec "$CTID" -- bash -c '

--- a/scripts/test_markdown_escape.sh
+++ b/scripts/test_markdown_escape.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+set -e
+
+# Test 1: Function simulating the escape logic
+escape_markdown() {
+  local str="$1"
+  str="${str//_/\\_}"
+  str="${str//\*/\\*}"
+  str="${str//\[/\\[}"
+  str="${str//\]/\\]}"
+  str="${str//\`/\\\`}"
+  echo "$str"
+}
+
+# Test input
+input_str='host_name*1[a]`'
+expected_output='host\_name\*1\[a\]\`'
+actual_output=$(escape_markdown "$input_str")
+
+if [[ "$actual_output" == "$expected_output" ]]; then
+  echo "✅ Markdown escape test passed."
+else
+  echo "❌ Markdown escape test failed!"
+  echo "Expected: $expected_output"
+  echo "Actual:   $actual_output"
+  exit 1
+fi

--- a/system-update-notifier.sh
+++ b/system-update-notifier.sh
@@ -2,7 +2,7 @@
 # System Update Notifier
 # Updates the host system via apt and sends a Telegram notification.
 
-SCRIPT_VERSION="v0.5.6"
+SCRIPT_VERSION="v0.5.7"
 
 export PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 
@@ -27,6 +27,14 @@ elif [[ -f "/etc/pve-telegram.conf" ]]; then
   source "/etc/pve-telegram.conf"
 fi
 TOKEN="${TOKEN:-}"; CHAT_ID="${CHAT_ID:-}"; HOSTNAME="${HOSTNAME:-$(hostname -f 2>/dev/null || hostname)}"
+
+# 🛡️ Sentinel Security Fix: Escape Markdown control characters to prevent Telegram API injection DoS
+HOSTNAME="${HOSTNAME//_/\\_}"
+HOSTNAME="${HOSTNAME//\*/\\*}"
+HOSTNAME="${HOSTNAME//\[/\\[}"
+HOSTNAME="${HOSTNAME//\]/\\]}"
+HOSTNAME="${HOSTNAME//\`/\\\`}"
+
 AUTO_UPDATE="${AUTO_UPDATE:-no}" # Set to "yes" to enable automatic script updates from GitHub
 
 # --- TELEGRAM SEND ---
@@ -206,7 +214,9 @@ if [[ -f /var/run/reboot-required ]]; then REBOOT_REQ=" (reboot required)"; fi
 REPORT="*🔔 System Update Report: $HOSTNAME*"$'\n\n'
 REPORT+="✅ *$PACKAGE_COUNT packages installed:*"$'\n'
 for pkg in $UPGRADE_LIST; do 
-  REPORT+="• $pkg"$'\n'
+  # 🛡️ Sentinel Security Fix: Escape Markdown control characters in package names (e.g. libssl_1.1) to prevent Telegram API injection DoS
+  clean_pkg="${pkg//_/\\_}"
+  REPORT+="• $clean_pkg"$'\n'
 done
 
 REBOOT_NOTE=""


### PR DESCRIPTION
This pull request addresses a HIGH severity vulnerability where unsanitized external variables used in Telegram messages could cause a silent denial-of-service (DoS) on notifications by injecting unclosed Markdown characters, breaking the Telegram API.

### Changes:
- **Sanitized `HOSTNAME`:** Escaped Markdown control characters (`_`, `*`, `[`, `]`, `` ` ``) in `HOSTNAME` across `lxc-updater.sh`, `pve-update-notifier.sh`, and `system-update-notifier.sh`.
- **Sanitized Container Names:** Escaped Markdown control characters in `ctname` / `CTNAME` in `lxc-updater.sh` and `pve-update-notifier.sh`.
- **Sanitized Package Names:** Escaped Markdown control characters in package names (e.g., `libssl_1.1`) in `system-update-notifier.sh`.
- **Version Bump:** Bumped `SCRIPT_VERSION` in all three scripts to `v0.5.7` to comply with the project's versioning rules.
- **Testing:** Added local testing using `scripts/test_markdown_escape.sh` and a GitHub Actions workflow `.github/workflows/test.yml` to automatically execute tests for both local and CI execution.

---
*PR created automatically by Jules for task [12116270727820484038](https://jules.google.com/task/12116270727820484038) started by @spupuz*