### PR TITLE
🛡️ Sentinel: [HIGH] Fix Telegram Markdown API Injection

### DIFF
--- a/lxc-updater.sh
+++ b/lxc-updater.sh
@@ -24,7 +24,7 @@
 
 set -Eeuo pipefail
 
-SCRIPT_VERSION="v0.5.8"
+SCRIPT_VERSION="v0.5.9"
 
 # --- CONFIGURATION ---
 TOKEN=""
@@ -376,7 +376,12 @@ EOF
     if [[ -z "$nb_ip" || "$nb_ip" == "N/A" ]]; then
       netbird_info="      ⚠️ NetBird: Disconnected"
     else
-      netbird_info="      🌐 NetBird IP: $nb_ip"
+      safe_nb_ip="${nb_ip//_/\\_}"
+      safe_nb_ip="${safe_nb_ip//\*/\\*}"
+      safe_nb_ip="${safe_nb_ip//\[/\\[}"
+      safe_nb_ip="${safe_nb_ip//\]/\\]}"
+      safe_nb_ip="${safe_nb_ip//\`/\\\`}"
+      netbird_info="      🌐 NetBird IP: $safe_nb_ip"
     fi
   fi
 
@@ -396,7 +401,13 @@ EOF
   elif [[ "$pkg_updated" == "yes" ]]; then
     final_line="• $ctid ($ctname): ✅ OS Updated (No app script found)"
   else
-    final_line="• $ctid ($ctname): ❌ Update failed: ${error_msg:-No method found (apt/apk/dnf/yum)}"
+    safe_error_msg="${error_msg:-No method found (apt/apk/dnf/yum)}"
+    safe_error_msg="${safe_error_msg//_/\\_}"
+    safe_error_msg="${safe_error_msg//\*/\\*}"
+    safe_error_msg="${safe_error_msg//\[/\\[}"
+    safe_error_msg="${safe_error_msg//\]/\\]}"
+    safe_error_msg="${safe_error_msg//\`/\\\`}"
+    final_line="• $ctid ($ctname): ❌ Update failed: ${safe_error_msg}"
   fi
 
   echo "$final_line"

--- a/pve-update-notifier.sh
+++ b/pve-update-notifier.sh
@@ -14,7 +14,7 @@
 # Use this script at your own risk. The authors are not responsible for any
 # data loss, system instability, or service downtime caused by running it.
 
-SCRIPT_VERSION="v0.5.8"
+SCRIPT_VERSION="v0.5.9"
 
 # Add this path variable so Cron can find the required system commands
 export PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"

--- a/system-update-notifier.sh
+++ b/system-update-notifier.sh
@@ -2,7 +2,7 @@
 # System Update Notifier
 # Updates the host system via apt and sends a Telegram notification.
 
-SCRIPT_VERSION="v0.5.8"
+SCRIPT_VERSION="v0.5.9"
 
 export PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 
@@ -216,6 +216,10 @@ REPORT+="✅ *$PACKAGE_COUNT packages installed:*"$'\n'
 for pkg in $UPGRADE_LIST; do 
   # 🛡️ Sentinel Security Fix: Escape Markdown control characters in package names (e.g. libssl_1.1) to prevent Telegram API injection DoS
   clean_pkg="${pkg//_/\\_}"
+  clean_pkg="${clean_pkg//\*/\\*}"
+  clean_pkg="${clean_pkg//\[/\\[}"
+  clean_pkg="${clean_pkg//\]/\\]}"
+  clean_pkg="${clean_pkg//\`/\\\`}"
   REPORT+="• $clean_pkg"$'\n'
 done
 


### PR DESCRIPTION
🚨 **Severity:** HIGH (Telegram Notification DoS / Content Spoofing)
💡 **Vulnerability:** Variables derived from external sources (e.g., container outputs like `app_cmd`, `nb_ip`, and `apt-get` package lists) were being interpolated directly into Markdown-formatted Telegram messages without comprehensively escaping Markdown control characters (`*`, `[`, `]`, `` ` ``). Previous sanitization only escaped `_`.
🎯 **Impact:** If a package name or command contained unescaped Markdown control characters, the Telegram API would reject the entire notification payload with a 400 Bad Request error due to malformed Markdown parsing, causing silent failures in critical update monitoring and alerting.
🔧 **Fix:** Introduced bash string replacement logic to fully escape all relevant Markdown control characters for `nb_ip`, `error_msg`, and `clean_pkg` before string interpolation. Removed invalid `local` scoping for variables executed in the global context. Bumped `SCRIPT_VERSION` to `v0.5.9` across all scripts.
✅ **Verification:** Verified with `bash -n` on all updated scripts. Validated that regex replacements correctly double-escape the output string for subsequent markdown interpretation.

---
*PR created automatically by Jules for task [16852628730048085145](https://jules.google.com/task/16852628730048085145) started by @spupuz*