### PR TITLE
🎨 Palette: [UX improvement] Add actionable hints to generic error messages

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,4 @@
+
+## 2024-05-18 - Actionable Error Feedback
+**Learning:** Silent failures and generic error states in CLI tools often lead to a false sense of security (e.g., falsely reporting a system as up-to-date) and leave users without clear troubleshooting paths.
+**Action:** Pair all generic error states in CLI outputs and notifications with immediate, actionable hints (e.g., "Check network or apt locks", "Container offline or timed out") to minimize user friction and confusion.

--- a/lxc-updater.sh
+++ b/lxc-updater.sh
@@ -24,7 +24,7 @@
 
 set -Eeuo pipefail
 
-SCRIPT_VERSION="v0.5.8"
+SCRIPT_VERSION="v0.5.9"
 
 # --- CONFIGURATION ---
 TOKEN=""
@@ -311,7 +311,7 @@ EOF
       app_updated="yes"
       log INFO "  -> App update completed successfully"
     else
-      error_msg="App update script ($app_cmd) failed."
+      error_msg="App update script ($app_cmd) failed (Check script logs or container network)."
       log WARN "  -> App update failed"
     fi
   fi
@@ -322,25 +322,25 @@ EOF
     if run_in_ct "$ctid" "sleep 2; export DEBIAN_FRONTEND=noninteractive; apt-get update -o Acquire::http::Timeout=10 -o Acquire::ftp::Timeout=10 -o Acquire::Retries=1; apt-get dist-upgrade -y -o Dpkg::Options::=\"--force-confold\" -o Dpkg::Options::=\"--force-confdef\" && apt-get autoremove -y && apt-get clean" >&2; then
       pkg_updated="yes"
     else
-      error_msg="${error_msg:+$error_msg; }APT update failed"
+      error_msg="${error_msg:+$error_msg; }APT update failed (Check network or apt locks)"
     fi
   elif [[ "$pkg_mgr" == "apk" ]]; then
     if run_in_ct "$ctid" "apk update && apk upgrade" >&2; then
       pkg_updated="yes"
     else
-      error_msg="${error_msg:+$error_msg; }APK update failed"
+      error_msg="${error_msg:+$error_msg; }APK update failed (Check network or repos)"
     fi
   elif [[ "$pkg_mgr" == "dnf" ]]; then
     if run_in_ct "$ctid" "dnf -y upgrade --refresh" >&2; then
       pkg_updated="yes"
     else
-      error_msg="${error_msg:+$error_msg; }DNF update failed"
+      error_msg="${error_msg:+$error_msg; }DNF update failed (Check network or repos)"
     fi
   elif [[ "$pkg_mgr" == "yum" ]]; then
     if run_in_ct "$ctid" "yum -y update" >&2; then
       pkg_updated="yes"
     else
-      error_msg="${error_msg:+$error_msg; }YUM update failed"
+      error_msg="${error_msg:+$error_msg; }YUM update failed (Check network or repos)"
     fi
   fi
 

--- a/pve-update-notifier.sh
+++ b/pve-update-notifier.sh
@@ -14,7 +14,7 @@
 # Use this script at your own risk. The authors are not responsible for any
 # data loss, system instability, or service downtime caused by running it.
 
-SCRIPT_VERSION="v0.5.8"
+SCRIPT_VERSION="v0.5.9"
 
 # Add this path variable so Cron can find the required system commands
 export PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
@@ -225,16 +225,19 @@ REPORT="*🔔 Update Report: $HOSTNAME*"$'\n\n'
 
 # 1. CHECK PROXMOX HOST
 log INFO "Checking Proxmox Host..."
-apt-get update -o Acquire::http::Timeout=10 -o Acquire::ftp::Timeout=10 -o Acquire::Retries=1 > /dev/null 2>&1
-HOST_UPDATES=$(apt-get -s upgrade | grep -P '^\d+ upgraded' | cut -d' ' -f1)
+if apt-get update -o Acquire::http::Timeout=10 -o Acquire::ftp::Timeout=10 -o Acquire::Retries=1 > /dev/null 2>&1; then
+    HOST_UPDATES=$(apt-get -s upgrade | grep -P '^\d+ upgraded' | cut -d' ' -f1)
 
-# Sanitize to prevent command injection
-HOST_UPDATES_CLEAN="${HOST_UPDATES//[^0-9]/}"
+    # Sanitize to prevent command injection
+    HOST_UPDATES_CLEAN="${HOST_UPDATES//[^0-9]/}"
 
-if [ -z "$HOST_UPDATES_CLEAN" ] || [ "$HOST_UPDATES_CLEAN" -eq 0 ]; then
-    REPORT+="🖥️ *Proxmox Host*: ✅ Up to date"$'\n'
+    if [ -z "$HOST_UPDATES_CLEAN" ] || [ "$HOST_UPDATES_CLEAN" -eq 0 ]; then
+        REPORT+="🖥️ *Proxmox Host*: ✅ Up to date"$'\n'
+    else
+        REPORT+="🖥️ *Proxmox Host*: ⚠️ $HOST_UPDATES_CLEAN updates available"$'\n'
+    fi
 else
-    REPORT+="🖥️ *Proxmox Host*: ⚠️ $HOST_UPDATES_CLEAN updates available"$'\n'
+    REPORT+="🖥️ *Proxmox Host*: ❌ Error during check (Check network or apt locks)"$'\n'
 fi
 
 if $IS_PVE_HOST; then
@@ -265,8 +268,11 @@ if $IS_PVE_HOST; then
                   exit 0
               fi
               # We use a host-level timeout and apt timeouts to prevent hung processes if container networking is down
-              apt-get update -o Acquire::http::Timeout=10 -o Acquire::ftp::Timeout=10 -o Acquire::Retries=1 > /dev/null 2>&1
-              apt-get -s upgrade 2>/dev/null | grep -P "^\d+ upgraded" | cut -d" " -f1 || echo "0"
+              if apt-get update -o Acquire::http::Timeout=10 -o Acquire::ftp::Timeout=10 -o Acquire::Retries=1 > /dev/null 2>&1; then
+                  apt-get -s upgrade 2>/dev/null | grep -P "^\d+ upgraded" | cut -d" " -f1 || echo "0"
+              else
+                  echo "ERROR"
+              fi
           ' || echo "ERROR")
 
           # Sanitize to prevent command injection

--- a/system-update-notifier.sh
+++ b/system-update-notifier.sh
@@ -2,7 +2,7 @@
 # System Update Notifier
 # Updates the host system via apt and sends a Telegram notification.
 
-SCRIPT_VERSION="v0.5.8"
+SCRIPT_VERSION="v0.5.9"
 
 export PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 


### PR DESCRIPTION
🎨 Palette: [UX improvement] Add actionable hints to generic error messages and fix silent check failure

💡 What:
- Updated generic `error_msg` strings in `lxc-updater.sh` to include specific, actionable troubleshooting hints (e.g., "(Check network or apt locks)").
- Fixed a false positive in `pve-update-notifier.sh` where a failing host `apt-get update` would silently be ignored and falsely report the system as up to date. It now correctly reports an error state with an actionable hint.
- Handled the same failure gracefully for LXC checks in `pve-update-notifier.sh`.
- Bumped `SCRIPT_VERSION` to `v0.5.9` across all scripts per `AGENTS.md`.

🎯 Why:
- Generic error messages like "APT update failed" leave users confused about the next step. Providing immediate hints reduces friction and support requests.
- Falsely reporting a system as "✅ Up to date" when the check itself failed due to network or apt lock issues creates a dangerous false sense of security. The CLI tool must be honest about check failures.

♿ Accessibility:
- Improves cognitive accessibility by providing clear, actionable feedback instead of dead-end error states, allowing users to self-recover more easily.

---
*PR created automatically by Jules for task [1930512110927929972](https://jules.google.com/task/1930512110927929972) started by @spupuz*