### PR TITLE
🛡️ Sentinel: Fix command option injection in logger wrapper

### DIFF
--- a/lxc-updater.sh
+++ b/lxc-updater.sh
@@ -24,7 +24,7 @@
 
 set -Eeuo pipefail
 
-SCRIPT_VERSION="v0.5.9"
+SCRIPT_VERSION="v0.5.10"
 
 # --- CONFIGURATION ---
 TOKEN=""
@@ -89,7 +89,7 @@ log() {
   fi
 
   if command -v logger &>/dev/null; then
-    logger -t "lxc-updater" -p "user.${level,,}" "$*" 2>/dev/null || true
+    logger -t "lxc-updater" -p "user.${level,,}" -- "$*" 2>/dev/null || true
   fi
 }
 

--- a/pve-update-notifier.sh
+++ b/pve-update-notifier.sh
@@ -14,7 +14,7 @@
 # Use this script at your own risk. The authors are not responsible for any
 # data loss, system instability, or service downtime caused by running it.
 
-SCRIPT_VERSION="v0.5.9"
+SCRIPT_VERSION="v0.5.10"
 
 # Add this path variable so Cron can find the required system commands
 export PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
@@ -34,7 +34,7 @@ log() {
   fi
 
   if command -v logger &>/dev/null; then
-    logger -t "pve-update-notifier" -p "user.${level,,}" "$*" 2>/dev/null || true
+    logger -t "pve-update-notifier" -p "user.${level,,}" -- "$*" 2>/dev/null || true
   fi
 }
 

--- a/system-update-notifier.sh
+++ b/system-update-notifier.sh
@@ -2,7 +2,7 @@
 # System Update Notifier
 # Updates the host system via apt and sends a Telegram notification.
 
-SCRIPT_VERSION="v0.5.9"
+SCRIPT_VERSION="v0.5.10"
 
 export PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 
@@ -13,7 +13,7 @@ log(){
   local ts; ts=$(date '+%Y-%m-%d %H:%M:%S')
   local msg="${ts} [${lvl}] $*"
   [[ "$LOG_STDOUT" == "yes" ]] && echo "$msg" >&2
-  command -v logger &>/dev/null && logger -t "system-update-notifier" -p "user.${lvl,,}" "$*" 2>/dev/null || true
+  command -v logger &>/dev/null && logger -t "system-update-notifier" -p "user.${lvl,,}" -- "$*" 2>/dev/null || true
 }
 
 # --- CONFIGURATION ---


### PR DESCRIPTION
🚨 **Severity:** MEDIUM
💡 **Vulnerability:** Command Option Injection in bash logging wrapper functions calling `logger`. Passing string variables (like log messages) to external commands without `--` can allow leading hyphens to be misinterpreted as command-line flags.
🎯 **Impact:** Potential for unintended behavior in logging utility, such as reading local files if `-f filename` were injected as a log message.
🔧 **Fix:** Added `--` end-of-options separator to all `logger` command calls in `lxc-updater.sh`, `pve-update-notifier.sh`, and `system-update-notifier.sh` to ensure all subsequent parameters are treated strictly as positional arguments.
✅ **Verification:** Verified syntax correctness using `bash -n` across modified scripts.

Additionally, synchronized the version bump (`v0.5.10`) across all scripts as specified by `AGENTS.md`.

---
*PR created automatically by Jules for task [11652774905712144835](https://jules.google.com/task/11652774905712144835) started by @spupuz*