### PR TITLE
🛡️ Sentinel: [HIGH] Fix command option injection in logger calls

### DIFF
--- a/lxc-updater.sh
+++ b/lxc-updater.sh
@@ -24,7 +24,7 @@
 
 set -Eeuo pipefail
 
-SCRIPT_VERSION="v0.5.9"
+SCRIPT_VERSION="v0.5.10"
 
 # --- CONFIGURATION ---
 TOKEN=""
@@ -89,7 +89,8 @@ log() {
   fi
 
   if command -v logger &>/dev/null; then
-    logger -t "lxc-updater" -p "user.${level,,}" "$*" 2>/dev/null || true
+    # 🛡️ Sentinel Security Fix: Prevent command option injection in logger
+    logger -t "lxc-updater" -p "user.${level,,}" -- "$*" 2>/dev/null || true
   fi
 }
 

--- a/pve-update-notifier.sh
+++ b/pve-update-notifier.sh
@@ -14,7 +14,7 @@
 # Use this script at your own risk. The authors are not responsible for any
 # data loss, system instability, or service downtime caused by running it.
 
-SCRIPT_VERSION="v0.5.9"
+SCRIPT_VERSION="v0.5.10"
 
 # Add this path variable so Cron can find the required system commands
 export PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
@@ -34,7 +34,8 @@ log() {
   fi
 
   if command -v logger &>/dev/null; then
-    logger -t "pve-update-notifier" -p "user.${level,,}" "$*" 2>/dev/null || true
+    # 🛡️ Sentinel Security Fix: Prevent command option injection in logger
+    logger -t "pve-update-notifier" -p "user.${level,,}" -- "$*" 2>/dev/null || true
   fi
 }
 

--- a/system-update-notifier.sh
+++ b/system-update-notifier.sh
@@ -2,7 +2,7 @@
 # System Update Notifier
 # Updates the host system via apt and sends a Telegram notification.
 
-SCRIPT_VERSION="v0.5.9"
+SCRIPT_VERSION="v0.5.10"
 
 export PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 
@@ -13,7 +13,8 @@ log(){
   local ts; ts=$(date '+%Y-%m-%d %H:%M:%S')
   local msg="${ts} [${lvl}] $*"
   [[ "$LOG_STDOUT" == "yes" ]] && echo "$msg" >&2
-  command -v logger &>/dev/null && logger -t "system-update-notifier" -p "user.${lvl,,}" "$*" 2>/dev/null || true
+  # 🛡️ Sentinel Security Fix: Prevent command option injection in logger
+  command -v logger &>/dev/null && logger -t "system-update-notifier" -p "user.${lvl,,}" -- "$*" 2>/dev/null || true
 }
 
 # --- CONFIGURATION ---


### PR DESCRIPTION
**🚨 Severity:** HIGH
**💡 Vulnerability:** Arbitrary log messages derived from external sources or arguments could be interpreted as command-line options by `logger` if they start with a hyphen, potentially causing command injection or unexpected behavior (e.g., `-f`, `-e`).
**🎯 Impact:** Potential local privilege escalation or denial of service if un-sanitized data starting with a dash is passed to `logger` via the `log()` functions, especially since these scripts execute as root.
**🔧 Fix:** Added the standard `--` end-of-options separator to all `logger` calls across `lxc-updater.sh`, `pve-update-notifier.sh`, and `system-update-notifier.sh` to strictly parse subsequent input as strings, preventing option injection.
**✅ Verification:** Verified syntactically with `bash -n *.sh`. Included `SCRIPT_VERSION` bump.

---
*PR created automatically by Jules for task [5789506710080615804](https://jules.google.com/task/5789506710080615804) started by @spupuz*