### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix arbitrary file overwrite via symlink attack

### DIFF
--- a/lxc-updater.sh
+++ b/lxc-updater.sh
@@ -24,7 +24,7 @@
 
 set -Eeuo pipefail
 
-SCRIPT_VERSION="v0.5.10"
+SCRIPT_VERSION="v0.5.11"
 
 # --- CONFIGURATION ---
 TOKEN=""
@@ -198,6 +198,7 @@ Run \`bash ${script_name} --update\` to install."
     "https://raw.githubusercontent.com/spupuz/proxmox-scripts/${latest_tag}/${script_name}"; then
 
     if head -1 "$tmp_file" | grep -q '^#!'; then
+      rm -f "${BASH_SOURCE[0]}.bak" # 🛡️ Sentinel Security Fix: Prevent symlink attack via cp
       cp "${BASH_SOURCE[0]}" "${BASH_SOURCE[0]}.bak"
       mv "$tmp_file" "${BASH_SOURCE[0]}"
       chmod +x "${BASH_SOURCE[0]}"

--- a/pve-update-notifier.sh
+++ b/pve-update-notifier.sh
@@ -14,7 +14,7 @@
 # Use this script at your own risk. The authors are not responsible for any
 # data loss, system instability, or service downtime caused by running it.
 
-SCRIPT_VERSION="v0.5.10"
+SCRIPT_VERSION="v0.5.11"
 
 # Add this path variable so Cron can find the required system commands
 export PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
@@ -169,6 +169,7 @@ Run \`bash ${script_name} --update\` to install."
     "https://raw.githubusercontent.com/spupuz/proxmox-scripts/${latest_tag}/${script_name}"; then
 
     if head -1 "$tmp_file" | grep -q '^#!'; then
+      rm -f "${BASH_SOURCE[0]}.bak" # 🛡️ Sentinel Security Fix: Prevent symlink attack via cp
       cp "${BASH_SOURCE[0]}" "${BASH_SOURCE[0]}.bak"
       mv "$tmp_file" "${BASH_SOURCE[0]}"
       chmod +x "${BASH_SOURCE[0]}"

--- a/system-update-notifier.sh
+++ b/system-update-notifier.sh
@@ -2,7 +2,7 @@
 # System Update Notifier
 # Updates the host system via apt and sends a Telegram notification.
 
-SCRIPT_VERSION="v0.5.10"
+SCRIPT_VERSION="v0.5.11"
 
 export PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 
@@ -133,6 +133,7 @@ Run \`bash ${script_name} --update\` to install."
     "https://raw.githubusercontent.com/spupuz/proxmox-scripts/${latest_tag}/${script_name}"; then
 
     if head -1 "$tmp_file" | grep -q '^#!'; then
+      rm -f "${BASH_SOURCE[0]}.bak" # 🛡️ Sentinel Security Fix: Prevent symlink attack via cp
       cp "${BASH_SOURCE[0]}" "${BASH_SOURCE[0]}.bak"
       mv "$tmp_file" "${BASH_SOURCE[0]}"
       chmod +x "${BASH_SOURCE[0]}"


### PR DESCRIPTION
🛡️ Sentinel: [CRITICAL] Fix arbitrary file overwrite via symlink attack

🚨 Severity: CRITICAL
💡 Vulnerability: When the auto-update function applies a downloaded update, it backs up the running script using `cp "${BASH_SOURCE[0]}" "${BASH_SOURCE[0]}.bak"`. By default, `cp` follows symlinks at the destination path. If a local attacker pre-creates the `.bak` file as a symlink to an arbitrary system file (e.g., `/etc/shadow`), the script (running as root) would overwrite the target system file with the script's content.
🎯 Impact: Local privilege escalation / arbitrary file overwrite.
🔧 Fix: Added `rm -f "${BASH_SOURCE[0]}.bak"` before executing `cp` to ensure the backup destination is clear and any malicious symlink is safely unlinked without being followed. Bumped SCRIPT_VERSION to v0.5.11 across all scripts.
✅ Verification: Tested via syntax check (`bash -n`) and verified `rm -f` behavior manually in an isolated directory.

---
*PR created automatically by Jules for task [15453186166226781550](https://jules.google.com/task/15453186166226781550) started by @spupuz*