### PR TITLE
🛡️ Sentinel: [Enhancement] Add timeouts to Telegram API calls and fix temp dir leak

### DIFF
--- a/lxc-updater.sh
+++ b/lxc-updater.sh
@@ -24,7 +24,7 @@
 
 set -Eeuo pipefail
 
-SCRIPT_VERSION="v0.5.11"
+SCRIPT_VERSION="v0.5.12"
 
 # --- CONFIGURATION ---
 TOKEN=""
@@ -105,7 +105,7 @@ send_telegram() {
 
     # 🛡️ Sentinel Security Fix: Prevent TOKEN leakage and fix ARG_MAX for large reports.
     # Use process substitution for config and pass the message body via stdin.
-    RESPONSE=$(curl -s -X POST -K <(cat <<CURL_CONF
+    RESPONSE=$(curl -s --connect-timeout 10 --max-time 30 -X POST -K <(cat <<CURL_CONF
 url = "$URL"
 data-urlencode = "chat_id=$CHAT_ID"
 data-urlencode = "parse_mode=Markdown"

--- a/pve-update-notifier.sh
+++ b/pve-update-notifier.sh
@@ -14,7 +14,7 @@
 # Use this script at your own risk. The authors are not responsible for any
 # data loss, system instability, or service downtime caused by running it.
 
-SCRIPT_VERSION="v0.5.11"
+SCRIPT_VERSION="v0.5.12"
 
 # Add this path variable so Cron can find the required system commands
 export PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
@@ -76,7 +76,7 @@ send_telegram() {
 
     # 🛡️ Sentinel Security Fix: Prevent TOKEN leakage and fix ARG_MAX for large reports.
     # Use process substitution for config and pass the message body via stdin.
-    RESPONSE=$(curl -s -X POST -K <(cat <<CURL_CONF
+    RESPONSE=$(curl -s --connect-timeout 10 --max-time 30 -X POST -K <(cat <<CURL_CONF
 url = "$URL"
 data-urlencode = "chat_id=$CHAT_ID"
 data-urlencode = "parse_mode=Markdown"
@@ -253,6 +253,7 @@ if $IS_PVE_HOST; then
   else
       # ⚡ Bolt: Use a temporary directory to store bounded concurrent execution results
       TMP_DIR=$(mktemp -d "/tmp/pve-update-notifier.XXXXXX")
+      trap 'rm -rf "$TMP_DIR"' EXIT
       MAX_JOBS=5
 
       for item in "${lxc_list[@]}"; do

--- a/system-update-notifier.sh
+++ b/system-update-notifier.sh
@@ -2,7 +2,7 @@
 # System Update Notifier
 # Updates the host system via apt and sends a Telegram notification.
 
-SCRIPT_VERSION="v0.5.11"
+SCRIPT_VERSION="v0.5.12"
 
 export PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 
@@ -45,7 +45,7 @@ send_telegram(){
   local URL="https://api.telegram.org/bot${TOKEN}/sendMessage"
   # 🛡️ Sentinel Security Fix: Prevent TOKEN leakage and fix ARG_MAX for large reports.
   # Use process substitution for config and pass the message body via stdin.
-  local RESPONSE=$(curl -s -X POST -K <(cat <<CURL_CONF
+  local RESPONSE=$(curl -s --connect-timeout 10 --max-time 30 -X POST -K <(cat <<CURL_CONF
 url = "$URL"
 data-urlencode = "chat_id=$CHAT_ID"
 data-urlencode = "parse_mode=Markdown"


### PR DESCRIPTION
🚨 Severity: HIGH (DoS via resource exhaustion / Resource Leak)
💡 Vulnerability: 
1. Missing timeouts on external API calls (`curl` to Telegram) within automated cron scripts. If the endpoint is unresponsive, processes can accumulate endlessly and exhaust system resources.
2. Missing cleanup `trap` for a temporary directory in `pve-update-notifier.sh` leaves orphaned folders in `/tmp` upon forceful termination.
🎯 Impact: System Denial of Service (DoS) due to PID/memory exhaustion and `/tmp` directory pollution.
🔧 Fix: 
1. Added `--connect-timeout 10 --max-time 30` to `curl` calls across all scripts.
2. Added `trap 'rm -rf "$TMP_DIR"' EXIT` to `pve-update-notifier.sh` immediately after temporary directory creation.
✅ Verification: Ran `bash -n` to validate syntax on all modified scripts.

Version bumped to `v0.5.12`.

---
*PR created automatically by Jules for task [11226753377316922100](https://jules.google.com/task/11226753377316922100) started by @spupuz*