### PR TITLE
🎨 Palette: Merge user-facing lists into centralized log() payloads

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2023-10-27 - Centralized Logging for UX consistency
+**Learning:** Sequential `log` and `echo >&2` for outputting lists causes disjointed console output and misses capturing lists in syslogs.
+**Action:** Always pipe user-facing list output through the centralized `log()` function by merging them inside variables, appending visual list elements directly inside the single log payload.

--- a/system-update-notifier.sh
+++ b/system-update-notifier.sh
@@ -186,8 +186,8 @@ if [[ -z "$UPGRADE_LIST" ]]; then
 fi
 
 PACKAGE_COUNT=$(echo "$UPGRADE_LIST" | wc -w)
-log INFO "📋 Found $PACKAGE_COUNT packages to upgrade:"
-echo "$UPGRADE_LIST" | tr ' ' '\n' | sed 's/^/    ✓ /' >&2
+FORMATTED_LIST=$(echo "$UPGRADE_LIST" | tr ' ' '\n' | sed 's/^/    ✓ /')
+log INFO "📋 Found $PACKAGE_COUNT packages to upgrade:"$'\n'"$FORMATTED_LIST"
 
 log INFO "🔧 Installing system updates..."
 apt_log=$(mktemp "/tmp/apt-upgrade.XXXXXX")


### PR DESCRIPTION
* 💡 **What**: The script `system-update-notifier.sh` printed a user-facing list directly to `stderr` (`>&2`) using `echo`, immediately following a `log()` call. This disjointed the output and missed recording the list payload in syslogs. This is updated by formatting the list into a string and parsing it to the logger.
* 🎯 **Why**: Using sequential `echo` and `log()` causes inconsistent visual outputs and fails to record list objects into syslogs via the centralized `logger` utility.
* ♿ **Accessibility**: N/A - CLI UX consistency improvement.

---
*PR created automatically by Jules for task [7021408159242312004](https://jules.google.com/task/7021408159242312004) started by @spupuz*