### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix temporary directory cleanup leak in trap

### DIFF
--- a/lxc-updater.sh
+++ b/lxc-updater.sh
@@ -24,7 +24,7 @@
 
 set -Eeuo pipefail
 
-SCRIPT_VERSION="v0.5.12"
+SCRIPT_VERSION="v0.5.13"
 
 # --- CONFIGURATION ---
 TOKEN=""
@@ -480,7 +480,8 @@ main() {
     # ⚡ Bolt: Use a temporary directory to store bounded concurrent execution results
     local tmp_dir
     tmp_dir=$(mktemp -d "/tmp/lxc-updater.XXXXXX") || { log ERROR "❌ Failed to create temporary directory for concurrent execution"; exit 1; }
-    trap 'rm -rf "$tmp_dir"' EXIT
+    # 🛡️ Sentinel Security Fix: Interpolate local tmp_dir into trap immediately to prevent scope collapse leakage
+    trap "rm -rf \"$tmp_dir\"" EXIT
     local max_jobs=5
 
     for item in "${lxc_list[@]}"; do

--- a/pve-update-notifier.sh
+++ b/pve-update-notifier.sh
@@ -14,7 +14,7 @@
 # Use this script at your own risk. The authors are not responsible for any
 # data loss, system instability, or service downtime caused by running it.
 
-SCRIPT_VERSION="v0.5.12"
+SCRIPT_VERSION="v0.5.13"
 
 # Add this path variable so Cron can find the required system commands
 export PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"

--- a/system-update-notifier.sh
+++ b/system-update-notifier.sh
@@ -2,7 +2,7 @@
 # System Update Notifier
 # Updates the host system via apt and sends a Telegram notification.
 
-SCRIPT_VERSION="v0.5.12"
+SCRIPT_VERSION="v0.5.13"
 
 export PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 


### PR DESCRIPTION
### 🚨 Sentinel Fix: Prevent Local Variable Scope Collapse in `EXIT` Trap

**Vulnerability:** A subtle resource/privacy leak in `lxc-updater.sh` where a background cleanup routine `trap 'rm -rf "$tmp_dir"' EXIT` fails to trigger correctly. Because `tmp_dir` is defined as a `local` variable, it falls out of scope when the function returns. If the script exits after that point, the trap evaluates to `rm -rf ""`, leaving sensitive Proxmox operation temporary directories permanently stranded in `/tmp/`.

**Fix:** Changed the trap string to use standard double quotes (`trap "rm -rf \"$tmp_dir\"" EXIT`) without escaping the `$`. This ensures that the exact path of the temporary directory is resolved and embedded directly into the trap command at registration time, surviving any subsequent scope closures. 

Versions of all tracking scripts were successfully bumped to `v0.5.13` in compliance with `AGENTS.md`.

---
*PR created automatically by Jules for task [5440958913158027641](https://jules.google.com/task/5440958913158027641) started by @spupuz*