### PR TITLE
🛡️ Sentinel: Enforce secure protocols on curl downloads

### DIFF
--- a/lxc-updater.sh
+++ b/lxc-updater.sh
@@ -24,7 +24,7 @@
 
 set -Eeuo pipefail
 
-SCRIPT_VERSION="v0.5.13"
+SCRIPT_VERSION="v0.5.14"
 
 # --- CONFIGURATION ---
 TOKEN=""
@@ -105,7 +105,7 @@ send_telegram() {
 
     # 🛡️ Sentinel Security Fix: Prevent TOKEN leakage and fix ARG_MAX for large reports.
     # Use process substitution for config and pass the message body via stdin.
-    RESPONSE=$(curl -s --connect-timeout 10 --max-time 30 -X POST -K <(cat <<CURL_CONF
+    RESPONSE=$(curl --proto '=https' --tlsv1.2 -s --connect-timeout 10 --max-time 30 -X POST -K <(cat <<CURL_CONF
 url = "$URL"
 data-urlencode = "chat_id=$CHAT_ID"
 data-urlencode = "parse_mode=Markdown"
@@ -147,7 +147,7 @@ auto_update() {
   local auto_update_enabled="${AUTO_UPDATE:-no}"
 
   local latest_tag
-  latest_tag=$(curl -sI --connect-timeout 5 --max-time 10 \
+  latest_tag=$(curl --proto '=https' --tlsv1.2 -sI --connect-timeout 5 --max-time 10 \
     "https://github.com/spupuz/proxmox-scripts/releases/latest" \
     | grep -i '^location:' | sed 's|.*/tag/||' | tr -d '\r')
 
@@ -193,7 +193,7 @@ Run \`bash ${script_name} --update\` to install."
   local tmp_file
   tmp_file=$(mktemp "/tmp/${script_name}.XXXXXX") || return 1
 
-  if curl -sL --connect-timeout 5 --max-time 30 \
+  if curl --proto '=https' --tlsv1.2 -sL --connect-timeout 5 --max-time 30 \
     -o "$tmp_file" \
     "https://raw.githubusercontent.com/spupuz/proxmox-scripts/${latest_tag}/${script_name}"; then
 

--- a/pve-update-notifier.sh
+++ b/pve-update-notifier.sh
@@ -14,7 +14,7 @@
 # Use this script at your own risk. The authors are not responsible for any
 # data loss, system instability, or service downtime caused by running it.
 
-SCRIPT_VERSION="v0.5.13"
+SCRIPT_VERSION="v0.5.14"
 
 # Add this path variable so Cron can find the required system commands
 export PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
@@ -76,7 +76,7 @@ send_telegram() {
 
     # 🛡️ Sentinel Security Fix: Prevent TOKEN leakage and fix ARG_MAX for large reports.
     # Use process substitution for config and pass the message body via stdin.
-    RESPONSE=$(curl -s --connect-timeout 10 --max-time 30 -X POST -K <(cat <<CURL_CONF
+    RESPONSE=$(curl --proto '=https' --tlsv1.2 -s --connect-timeout 10 --max-time 30 -X POST -K <(cat <<CURL_CONF
 url = "$URL"
 data-urlencode = "chat_id=$CHAT_ID"
 data-urlencode = "parse_mode=Markdown"
@@ -118,7 +118,7 @@ auto_update() {
   local auto_update_enabled="${AUTO_UPDATE:-no}"
 
   local latest_tag
-  latest_tag=$(curl -sI --connect-timeout 5 --max-time 10 \
+  latest_tag=$(curl --proto '=https' --tlsv1.2 -sI --connect-timeout 5 --max-time 10 \
     "https://github.com/spupuz/proxmox-scripts/releases/latest" \
     | grep -i '^location:' | sed 's|.*/tag/||' | tr -d '\r')
 
@@ -164,7 +164,7 @@ Run \`bash ${script_name} --update\` to install."
   local tmp_file
   tmp_file=$(mktemp "/tmp/${script_name}.XXXXXX") || return 1
 
-  if curl -sL --connect-timeout 5 --max-time 30 \
+  if curl --proto '=https' --tlsv1.2 -sL --connect-timeout 5 --max-time 30 \
     -o "$tmp_file" \
     "https://raw.githubusercontent.com/spupuz/proxmox-scripts/${latest_tag}/${script_name}"; then
 

--- a/system-update-notifier.sh
+++ b/system-update-notifier.sh
@@ -2,7 +2,7 @@
 # System Update Notifier
 # Updates the host system via apt and sends a Telegram notification.
 
-SCRIPT_VERSION="v0.5.13"
+SCRIPT_VERSION="v0.5.14"
 
 export PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 
@@ -45,7 +45,7 @@ send_telegram(){
   local URL="https://api.telegram.org/bot${TOKEN}/sendMessage"
   # 🛡️ Sentinel Security Fix: Prevent TOKEN leakage and fix ARG_MAX for large reports.
   # Use process substitution for config and pass the message body via stdin.
-  local RESPONSE=$(curl -s --connect-timeout 10 --max-time 30 -X POST -K <(cat <<CURL_CONF
+  local RESPONSE=$(curl --proto '=https' --tlsv1.2 -s --connect-timeout 10 --max-time 30 -X POST -K <(cat <<CURL_CONF
 url = "$URL"
 data-urlencode = "chat_id=$CHAT_ID"
 data-urlencode = "parse_mode=Markdown"
@@ -82,7 +82,7 @@ auto_update() {
   local auto_update_enabled="${AUTO_UPDATE:-no}"
 
   local latest_tag
-  latest_tag=$(curl -sI --connect-timeout 5 --max-time 10 \
+  latest_tag=$(curl --proto '=https' --tlsv1.2 -sI --connect-timeout 5 --max-time 10 \
     "https://github.com/spupuz/proxmox-scripts/releases/latest" \
     | grep -i '^location:' | sed 's|.*/tag/||' | tr -d '\r')
 
@@ -128,7 +128,7 @@ Run \`bash ${script_name} --update\` to install."
   local tmp_file
   tmp_file=$(mktemp "/tmp/${script_name}.XXXXXX") || return 1
 
-  if curl -sL --connect-timeout 5 --max-time 30 \
+  if curl --proto '=https' --tlsv1.2 -sL --connect-timeout 5 --max-time 30 \
     -o "$tmp_file" \
     "https://raw.githubusercontent.com/spupuz/proxmox-scripts/${latest_tag}/${script_name}"; then
 


### PR DESCRIPTION
Added `--proto '=https' --tlsv1.2` to all curl commands to prevent protocol downgrades and insecure redirects. Bumps SCRIPT_VERSION.

---
*PR created automatically by Jules for task [6065919917255937279](https://jules.google.com/task/6065919917255937279) started by @spupuz*