### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix unchecked mktemp vulnerabilities

### DIFF
--- a/lxc-updater.sh
+++ b/lxc-updater.sh
@@ -24,7 +24,7 @@
 
 set -Eeuo pipefail
 
-SCRIPT_VERSION="v0.5.15"
+SCRIPT_VERSION="v0.5.16"
 
 # --- CONFIGURATION ---
 TOKEN=""

--- a/pve-update-notifier.sh
+++ b/pve-update-notifier.sh
@@ -14,7 +14,7 @@
 # Use this script at your own risk. The authors are not responsible for any
 # data loss, system instability, or service downtime caused by running it.
 
-SCRIPT_VERSION="v0.5.15"
+SCRIPT_VERSION="v0.5.16"
 
 # Add this path variable so Cron can find the required system commands
 export PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
@@ -252,7 +252,7 @@ if $IS_PVE_HOST; then
       REPORT+="• ⏭️ No running containers found"$'\n'
   else
       # ⚡ Bolt: Use a temporary directory to store bounded concurrent execution results
-      TMP_DIR=$(mktemp -d "/tmp/pve-update-notifier.XXXXXX")
+      TMP_DIR=$(mktemp -d "/tmp/pve-update-notifier.XXXXXX") || { log ERROR "❌ Failed to create temporary directory for concurrent execution"; exit 1; }
       trap 'rm -rf "$TMP_DIR"' EXIT
       MAX_JOBS=5
 

--- a/system-update-notifier.sh
+++ b/system-update-notifier.sh
@@ -2,7 +2,7 @@
 # System Update Notifier
 # Updates the host system via apt and sends a Telegram notification.
 
-SCRIPT_VERSION="v0.5.15"
+SCRIPT_VERSION="v0.5.16"
 
 export PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 
@@ -190,7 +190,7 @@ FORMATTED_LIST=$(echo "$UPGRADE_LIST" | tr ' ' '\n' | sed 's/^/    ✓ /')
 log INFO "ℹ️ Found $PACKAGE_COUNT packages to upgrade:"$'\n'"$FORMATTED_LIST"
 
 log INFO "ℹ️ Installing system updates..."
-apt_log=$(mktemp "/tmp/apt-upgrade.XXXXXX")
+apt_log=$(mktemp "/tmp/apt-upgrade.XXXXXX") || { log ERROR "❌ Failed to create temporary log file"; exit 1; }
 trap 'rm -f "$apt_log"' EXIT
 apt-get dist-upgrade -y -o Dpkg::Options::="--force-confold" -o Dpkg::Options::="--force-confdef" 2>&1 | tee "$apt_log" | grep -E '^(Get|Setting|Processing|done|Unpacking|Setting|upgraded|removed|newly installed|Preparing|^$)' >&2
 log INFO "✅ Installation completed"


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: Unchecked `mktemp` calls in bash scripts running as root can lead to the variable evaluating to an empty string on failure.
🎯 Impact: Subsequent file redirections using the variable (e.g., `> "$TMP_DIR/$CTID"`) write directly to the root filesystem (e.g., `> /100`), causing severe filesystem pollution or arbitrary file overwrites.
🔧 Fix: Suffix all `mktemp` calls with strict failure handling (`|| { log ERROR "..."; exit 1; }`).
✅ Verification: Ran `bash -n` and `shellcheck` (no warnings introduced). Evaluated logic to ensure standard script execution proceeds normally.

---
*PR created automatically by Jules for task [4517320430778240681](https://jules.google.com/task/4517320430778240681) started by @spupuz*