### PR TITLE
🎨 Palette: Add actionable hints to generic error states

### DIFF
--- a/lxc-updater.sh
+++ b/lxc-updater.sh
@@ -24,7 +24,7 @@
 
 set -Eeuo pipefail
 
-SCRIPT_VERSION="v0.6.1"
+SCRIPT_VERSION="v0.6.2"
 
 # --- CONFIGURATION ---
 TOKEN=""

--- a/pve-update-notifier.sh
+++ b/pve-update-notifier.sh
@@ -14,7 +14,7 @@
 # Use this script at your own risk. The authors are not responsible for any
 # data loss, system instability, or service downtime caused by running it.
 
-SCRIPT_VERSION="v0.6.1"
+SCRIPT_VERSION="v0.6.2"
 
 # Add this path variable so Cron can find the required system commands
 export PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
@@ -282,7 +282,7 @@ if $IS_PVE_HOST; then
       REPORT+="• ⏭️ No running containers found"$'\n'
   else
       # ⚡ Bolt: Use a temporary directory to store bounded concurrent execution results
-      TMP_DIR=$(mktemp -d "/tmp/pve-update-notifier.XXXXXX") || { log ERROR "❌ Failed to create temporary directory for concurrent execution"; exit 1; }
+      TMP_DIR=$(mktemp -d "/tmp/pve-update-notifier.XXXXXX") || { log ERROR "❌ Failed to create temporary directory for concurrent execution (Check /tmp permissions or disk space)"; exit 1; }
       trap 'rm -rf "$TMP_DIR"' EXIT
       MAX_JOBS=5
       running_jobs=0

--- a/system-update-notifier.sh
+++ b/system-update-notifier.sh
@@ -2,7 +2,7 @@
 # System Update Notifier
 # Updates the host system via apt and sends a Telegram notification.
 
-SCRIPT_VERSION="v0.6.1"
+SCRIPT_VERSION="v0.6.2"
 
 export PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 
@@ -220,7 +220,7 @@ FORMATTED_LIST=$(echo "$UPGRADE_LIST" | tr ' ' '\n' | sed 's/^/    ✓ /')
 log INFO "ℹ️ Found $PACKAGE_COUNT packages to upgrade:"$'\n'"$FORMATTED_LIST"
 
 log INFO "ℹ️ Installing system updates..."
-apt_log=$(mktemp "/tmp/apt-upgrade.XXXXXX") || { log ERROR "❌ Failed to create temporary log file"; exit 1; }
+apt_log=$(mktemp "/tmp/apt-upgrade.XXXXXX") || { log ERROR "❌ Failed to create temporary log file (Check /tmp permissions or disk space)"; exit 1; }
 trap 'rm -f "$apt_log"' EXIT
 apt-get dist-upgrade -y -o Dpkg::Options::="--force-confold" -o Dpkg::Options::="--force-confdef" 2>&1 | tee "$apt_log" | grep -E '^(Get|Setting|Processing|done|Unpacking|Setting|upgraded|removed|newly installed|Preparing|^$)' >&2
 log INFO "✅ Installation completed"


### PR DESCRIPTION
💡 What: Added actionable hints to generic file system errors for `mktemp`.
🎯 Why: System-level errors can leave users confused without context. Pairing generic errors with immediate, actionable hints minimizes friction and support requests.
📸 Before/After: CLI logs and Telegram alerts for temporary directory/file creation failures now include `(Check /tmp permissions or disk space)`.
♿ Accessibility: Improves CLI readability and scannability for error troubleshooting.

---
*PR created automatically by Jules for task [8217319430242046786](https://jules.google.com/task/8217319430242046786) started by @spupuz*