### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix privilege escalation via symlink attack in secure_source

### DIFF
--- a/lxc-updater.sh
+++ b/lxc-updater.sh
@@ -24,7 +24,7 @@
 
 set -Eeuo pipefail
 
-SCRIPT_VERSION="v0.6.3"
+SCRIPT_VERSION="v0.6.4"
 
 # --- LOGGING ---
 LOG_STDOUT="${LOG_STDOUT:-yes}" # Set to "no" to disable console output (useful for cron)
@@ -60,6 +60,10 @@ AUTO_UPDATE="no" # Set to "yes" to enable automatic script updates from GitHub.
 secure_source() {
   local conf_file="$1"
   if [[ ! -f "$conf_file" ]]; then return 0; fi
+  if [[ -h "$conf_file" ]]; then
+    log ERROR "❌ SECURITY CRITICAL: $conf_file is a symlink. Refusing to load to prevent privilege escalation."
+    return 1
+  fi
 
   local stat_out perms owner
   stat_out=$(stat -c "%a %U" "$conf_file" 2>/dev/null || echo "777 root")

--- a/pve-update-notifier.sh
+++ b/pve-update-notifier.sh
@@ -14,7 +14,7 @@
 # Use this script at your own risk. The authors are not responsible for any
 # data loss, system instability, or service downtime caused by running it.
 
-SCRIPT_VERSION="v0.6.3"
+SCRIPT_VERSION="v0.6.4"
 
 # Add this path variable so Cron can find the required system commands
 export PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
@@ -47,6 +47,10 @@ HOSTNAME=$(hostname -f)
 secure_source() {
   local conf_file="$1"
   if [[ ! -f "$conf_file" ]]; then return 0; fi
+  if [[ -h "$conf_file" ]]; then
+    log ERROR "❌ SECURITY CRITICAL: $conf_file is a symlink. Refusing to load to prevent privilege escalation."
+    return 1
+  fi
 
   local stat_out perms owner
   stat_out=$(stat -c "%a %U" "$conf_file" 2>/dev/null || echo "777 root")

--- a/system-update-notifier.sh
+++ b/system-update-notifier.sh
@@ -2,7 +2,7 @@
 # System Update Notifier
 # Updates the host system via apt and sends a Telegram notification.
 
-SCRIPT_VERSION="v0.6.3"
+SCRIPT_VERSION="v0.6.4"
 
 export PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 
@@ -25,6 +25,10 @@ HOSTNAME=$(hostname -f 2>/dev/null || hostname)
 secure_source() {
   local conf_file="$1"
   if [[ ! -f "$conf_file" ]]; then return 0; fi
+  if [[ -h "$conf_file" ]]; then
+    log ERROR "❌ SECURITY CRITICAL: $conf_file is a symlink. Refusing to load to prevent privilege escalation."
+    return 1
+  fi
 
   local stat_out perms owner
   stat_out=$(stat -c "%a %U" "$conf_file" 2>/dev/null || echo "777 root")


### PR DESCRIPTION
🛡️ Sentinel: [CRITICAL] Fix privilege escalation via symlink attack in secure_source

🚨 Severity: CRITICAL
💡 Vulnerability: The `secure_source` function checked file permissions using `stat`, and explicitly executed `chown root:root` and `chmod 600` if they didn't match `600 root`. If a malicious user replaced the config file with a symlink to their own script or another sensitive file, `chown` and `chmod` would follow the symlink, improperly changing file ownership and permissions. Finally, the script would `source` the attacker's script as `root`, leading to local privilege escalation (LPE).
🎯 Impact: Unprivileged users could gain root access or cause a Denial of Service by manipulating symlinks.
🔧 Fix: Added a `[[ -h "$conf_file" ]]` check in `secure_source` to explicitly reject symlinks before any properties are evaluated or changed.
✅ Verification: Tested via manual symlink reproduction and syntax check with `bash -n`.

---
*PR created automatically by Jules for task [1137265749860387468](https://jules.google.com/task/1137265749860387468) started by @spupuz*