### PR TITLE
🎨 Palette: Improve secure_source error actionability and log levels

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## YYYY-MM-DD - [Title]
+**Learning:** [UX/a11y insight]
+**Action:** [How to apply next time]

--- a/lxc-updater.sh
+++ b/lxc-updater.sh
@@ -24,7 +24,7 @@
 
 set -Eeuo pipefail
 
-SCRIPT_VERSION="v0.6.3"
+SCRIPT_VERSION="v0.6.4"
 
 # --- LOGGING ---
 LOG_STDOUT="${LOG_STDOUT:-yes}" # Set to "no" to disable console output (useful for cron)
@@ -68,11 +68,11 @@ secure_source() {
 
   if [[ "$perms" != "600" ]] || [[ "$owner" != "root" ]]; then
     log WARN "⚠️ SECURITY WARNING: Config file $conf_file has insecure permissions/ownership ($perms $owner)."
-    log WARN "Attempting to secure it to 600 root..."
+    log INFO "ℹ️ Attempting to secure it to 600 root..."
     if chown root:root "$conf_file" 2>/dev/null && chmod 600 "$conf_file" 2>/dev/null; then
       log INFO "✅ Successfully secured $conf_file permissions."
     else
-      log ERROR "❌ SECURITY CRITICAL: Cannot secure $conf_file. Refusing to load it to prevent arbitrary code execution."
+      log ERROR "❌ SECURITY CRITICAL: Cannot secure $conf_file. Refusing to load it to prevent arbitrary code execution. (Check file owner/permissions manually)"
       return 1
     fi
   fi

--- a/pve-update-notifier.sh
+++ b/pve-update-notifier.sh
@@ -14,7 +14,7 @@
 # Use this script at your own risk. The authors are not responsible for any
 # data loss, system instability, or service downtime caused by running it.
 
-SCRIPT_VERSION="v0.6.3"
+SCRIPT_VERSION="v0.6.4"
 
 # Add this path variable so Cron can find the required system commands
 export PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
@@ -55,11 +55,11 @@ secure_source() {
 
   if [[ "$perms" != "600" ]] || [[ "$owner" != "root" ]]; then
     log WARN "⚠️ SECURITY WARNING: Config file $conf_file has insecure permissions/ownership ($perms $owner)."
-    log WARN "Attempting to secure it to 600 root..."
+    log INFO "ℹ️ Attempting to secure it to 600 root..."
     if chown root:root "$conf_file" 2>/dev/null && chmod 600 "$conf_file" 2>/dev/null; then
       log INFO "✅ Successfully secured $conf_file permissions."
     else
-      log ERROR "❌ SECURITY CRITICAL: Cannot secure $conf_file. Refusing to load it to prevent arbitrary code execution."
+      log ERROR "❌ SECURITY CRITICAL: Cannot secure $conf_file. Refusing to load it to prevent arbitrary code execution. (Check file owner/permissions manually)"
       return 1
     fi
   fi

--- a/system-update-notifier.sh
+++ b/system-update-notifier.sh
@@ -2,7 +2,7 @@
 # System Update Notifier
 # Updates the host system via apt and sends a Telegram notification.
 
-SCRIPT_VERSION="v0.6.3"
+SCRIPT_VERSION="v0.6.4"
 
 export PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 
@@ -33,11 +33,11 @@ secure_source() {
 
   if [[ "$perms" != "600" ]] || [[ "$owner" != "root" ]]; then
     log WARN "⚠️ SECURITY WARNING: Config file $conf_file has insecure permissions/ownership ($perms $owner)."
-    log WARN "Attempting to secure it to 600 root..."
+    log INFO "ℹ️ Attempting to secure it to 600 root..."
     if chown root:root "$conf_file" 2>/dev/null && chmod 600 "$conf_file" 2>/dev/null; then
       log INFO "✅ Successfully secured $conf_file permissions."
     else
-      log ERROR "❌ SECURITY CRITICAL: Cannot secure $conf_file. Refusing to load it to prevent arbitrary code execution."
+      log ERROR "❌ SECURITY CRITICAL: Cannot secure $conf_file. Refusing to load it to prevent arbitrary code execution. (Check file owner/permissions manually)"
       return 1
     fi
   fi


### PR DESCRIPTION
💡 What:
- Changed the log level of "Attempting to secure it to 600 root..." from WARN to INFO and added the `ℹ️` emoji prefix.
- Added an actionable hint `(Check file owner/permissions manually)` to the `SECURITY CRITICAL: Cannot secure...` error message inside the `secure_source` function across all three main scripts.
- Bumped `SCRIPT_VERSION` in `lxc-updater.sh`, `pve-update-notifier.sh`, and `system-update-notifier.sh` from `v0.6.3` to `v0.6.4` to reflect these changes.

🎯 Why:
To ensure consistent visual scannability (emoji prefixes matching semantic log levels) across CLI outputs and provide immediate, actionable guidance for users when the automated file permission fix fails, minimizing user friction and confusion as per the Codebase UX standard.

♿ Accessibility:
Improves CLI readability and cognitive accessibility by clearly distinguishing information states from warnings and making error states immediately actionable.

---
*PR created automatically by Jules for task [10565481976685574849](https://jules.google.com/task/10565481976685574849) started by @spupuz*