### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix TOCTOU vulnerability in config loading

### DIFF
--- a/lxc-updater.sh
+++ b/lxc-updater.sh
@@ -24,7 +24,7 @@
 
 set -Eeuo pipefail
 
-SCRIPT_VERSION="v0.6.4"
+SCRIPT_VERSION="v0.6.5"
 
 # --- LOGGING ---
 LOG_STDOUT="${LOG_STDOUT:-yes}" # Set to "no" to disable console output (useful for cron)
@@ -71,14 +71,8 @@ secure_source() {
   owner="${stat_out#* }"
 
   if [[ "$perms" != "600" ]] || [[ "$owner" != "root" ]]; then
-    log WARN "⚠️ SECURITY WARNING: Config file $conf_file has insecure permissions/ownership ($perms $owner)."
-    log INFO "ℹ️ Attempting to secure it to 600 root..."
-    if chown root:root "$conf_file" 2>/dev/null && chmod 600 "$conf_file" 2>/dev/null; then
-      log INFO "✅ Successfully secured $conf_file permissions."
-    else
-      log ERROR "❌ SECURITY CRITICAL: Cannot secure $conf_file. Refusing to load it to prevent arbitrary code execution. (Check file owner/permissions manually)"
-      return 1
-    fi
+    log ERROR "❌ SECURITY CRITICAL: Config file $conf_file has insecure permissions/ownership ($perms $owner). Refusing to load it to prevent arbitrary code execution. (Please secure it manually: chown root:root and chmod 600)"
+    return 1
   fi
   source "$conf_file"
 }

--- a/pve-update-notifier.sh
+++ b/pve-update-notifier.sh
@@ -14,7 +14,7 @@
 # Use this script at your own risk. The authors are not responsible for any
 # data loss, system instability, or service downtime caused by running it.
 
-SCRIPT_VERSION="v0.6.4"
+SCRIPT_VERSION="v0.6.5"
 
 # Add this path variable so Cron can find the required system commands
 export PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
@@ -58,14 +58,8 @@ secure_source() {
   owner="${stat_out#* }"
 
   if [[ "$perms" != "600" ]] || [[ "$owner" != "root" ]]; then
-    log WARN "⚠️ SECURITY WARNING: Config file $conf_file has insecure permissions/ownership ($perms $owner)."
-    log INFO "ℹ️ Attempting to secure it to 600 root..."
-    if chown root:root "$conf_file" 2>/dev/null && chmod 600 "$conf_file" 2>/dev/null; then
-      log INFO "✅ Successfully secured $conf_file permissions."
-    else
-      log ERROR "❌ SECURITY CRITICAL: Cannot secure $conf_file. Refusing to load it to prevent arbitrary code execution. (Check file owner/permissions manually)"
-      return 1
-    fi
+    log ERROR "❌ SECURITY CRITICAL: Config file $conf_file has insecure permissions/ownership ($perms $owner). Refusing to load it to prevent arbitrary code execution. (Please secure it manually: chown root:root and chmod 600)"
+    return 1
   fi
   source "$conf_file"
 }

--- a/system-update-notifier.sh
+++ b/system-update-notifier.sh
@@ -2,7 +2,7 @@
 # System Update Notifier
 # Updates the host system via apt and sends a Telegram notification.
 
-SCRIPT_VERSION="v0.6.4"
+SCRIPT_VERSION="v0.6.5"
 
 export PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 
@@ -36,14 +36,8 @@ secure_source() {
   owner="${stat_out#* }"
 
   if [[ "$perms" != "600" ]] || [[ "$owner" != "root" ]]; then
-    log WARN "⚠️ SECURITY WARNING: Config file $conf_file has insecure permissions/ownership ($perms $owner)."
-    log INFO "ℹ️ Attempting to secure it to 600 root..."
-    if chown root:root "$conf_file" 2>/dev/null && chmod 600 "$conf_file" 2>/dev/null; then
-      log INFO "✅ Successfully secured $conf_file permissions."
-    else
-      log ERROR "❌ SECURITY CRITICAL: Cannot secure $conf_file. Refusing to load it to prevent arbitrary code execution. (Check file owner/permissions manually)"
-      return 1
-    fi
+    log ERROR "❌ SECURITY CRITICAL: Config file $conf_file has insecure permissions/ownership ($perms $owner). Refusing to load it to prevent arbitrary code execution. (Please secure it manually: chown root:root and chmod 600)"
+    return 1
   fi
   source "$conf_file"
 }


### PR DESCRIPTION
🛡️ Sentinel: [CRITICAL] Fix TOCTOU vulnerability in configuration loading

*🚨 Severity: CRITICAL*
*💡 Vulnerability: The `secure_source` function previously attempted to automatically remediate insecure permissions via `chown` and `chmod` after checking them with `stat`. This created a Time-Of-Check to Time-Of-Use (TOCTOU) vulnerability where an attacker could replace the config file with a symlink to a sensitive file (e.g., `/etc/shadow`) between the check and the remediation, leading to Local Privilege Escalation (LPE) as the script executed as root.
*🎯 Impact: Arbitrary root-level file permission and ownership manipulation, followed by potential arbitrary code execution if the file was successfully sourced.
*🔧 Fix: Removed the auto-remediation logic. The script now fails securely (`return 1`) and logs a clear error, instructing the user to manually secure the file permissions.
*✅ Verification: Verified script syntax using `bash -n` and executed existing tests.

Bumps `SCRIPT_VERSION` from `v0.6.4` to `v0.6.5` across all scripts.

---
*PR created automatically by Jules for task [12458833943120036136](https://jules.google.com/task/12458833943120036136) started by @spupuz*