### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix command injection in PVE heredocs

### DIFF
--- a/lxc-cleanup.sh
+++ b/lxc-cleanup.sh
@@ -324,6 +324,17 @@ get_disk_usage() {
 # --- CLEANUP LOGIC ---
 
 build_clean_script() {
+  # 🛡️ Sentinel Security Fix: Sanitize variables interpolated into unquoted heredoc executed via pct exec
+  # to prevent command injection from host-side variable expansion.
+  local safe_clean_pkg_cache="${CLEAN_PKG_CACHE//[^a-zA-Z0-9_-]/}"
+  local safe_clean_journal="${CLEAN_JOURNAL//[^a-zA-Z0-9_-]/}"
+  local safe_journal_vacuum_size="${JOURNAL_VACUUM_SIZE//[^a-zA-Z0-9_-]/}"
+  local safe_clean_docker="${CLEAN_DOCKER//[^a-zA-Z0-9_-]/}"
+  local safe_clean_docker_volume="${CLEAN_DOCKER_VOLUME_PRUNE//[^a-zA-Z0-9_-]/}"
+  local safe_clean_docker_tmp="${CLEAN_DOCKER_TMP//[^a-zA-Z0-9_-]/}"
+  local safe_clean_user_cache="${CLEAN_USER_CACHE//[^a-zA-Z0-9_-]/}"
+  local safe_clean_old_tmp="${CLEAN_OLD_TMP//[^a-zA-Z0-9_-]/}"
+
   read -r -d '' script << EOF || true
 set +e
 df_used() {
@@ -351,7 +362,7 @@ fi
 before_total=\$(df_used)
 
 # 1. PACKAGE MANAGER CACHES
-if [ "${CLEAN_PKG_CACHE}" = "yes" ]; then
+if [ "${safe_clean_pkg_cache}" = "yes" ]; then
   case "\$PKG_MGR" in
     apt-get)
       step PKG_CACHE 'apt-get autoremove -y --purge >/dev/null 2>&1; apt-get clean >/dev/null 2>&1; rm -rf /var/lib/apt/lists/* >/dev/null 2>&1'
@@ -369,32 +380,32 @@ if [ "${CLEAN_PKG_CACHE}" = "yes" ]; then
 fi
 
 # 2. SYSTEM LOGS (journald)
-if [ "${CLEAN_JOURNAL}" = "yes" ] && command -v journalctl >/dev/null 2>&1; then
-  step JOURNAL 'journalctl --vacuum-size=${JOURNAL_VACUUM_SIZE} >/dev/null 2>&1; journalctl --vacuum-time=7d >/dev/null 2>&1'
+if [ "${safe_clean_journal}" = "yes" ] && command -v journalctl >/dev/null 2>&1; then
+  step JOURNAL 'journalctl --vacuum-size=${safe_journal_vacuum_size} >/dev/null 2>&1; journalctl --vacuum-time=7d >/dev/null 2>&1'
 fi
 
 # 3. DOCKER (dangling images, build cache)
-if [ "${CLEAN_DOCKER}" = "yes" ] && command -v docker >/dev/null 2>&1; then
+if [ "${safe_clean_docker}" = "yes" ] && command -v docker >/dev/null 2>&1; then
   step DOCKER 'docker image prune -f >/dev/null 2>&1; docker builder prune -f >/dev/null 2>&1'
 fi
 
 # 3b. DOCKER VOLUMES (orphaned volumes) - ⚠️ opt-in, can delete volumes you want to keep
-if [ "${CLEAN_DOCKER_VOLUME_PRUNE}" = "yes" ] && command -v docker >/dev/null 2>&1; then
+if [ "${safe_clean_docker_volume}" = "yes" ] && command -v docker >/dev/null 2>&1; then
   step DOCKER_VOLUMES 'docker volume prune -f >/dev/null 2>&1'
 fi
 
 # 4. DOCKER CONTAINERS /tmp (old files in writable layers)
-if [ "${CLEAN_DOCKER_TMP}" = "yes" ] && command -v docker >/dev/null 2>&1; then
+if [ "${safe_clean_docker_tmp}" = "yes" ] && command -v docker >/dev/null 2>&1; then
   step DOCKER_TMP 'for dc in \$(docker ps -q 2>/dev/null); do [ -n "\$dc" ] || continue; docker exec "\$dc" sh -c "find /tmp -mindepth 1 -mtime +7 -exec rm -rf {} +" >/dev/null 2>&1 || true; done'
 fi
 
 # 5. USER CACHES (~/.cache, npm, pnpm, go)
-if [ "${CLEAN_USER_CACHE}" = "yes" ]; then
+if [ "${safe_clean_user_cache}" = "yes" ]; then
   step USER_CACHE 'for home in /root /home/*; do [ -d "\$home" ] || continue; rm -rf "\$home"/.cache/* >/dev/null 2>&1 || true; rm -rf "\$home"/.npm/_cacache >/dev/null 2>&1 || true; rm -rf "\$home"/.local/share/pnpm/store >/dev/null 2>&1 || true; rm -rf "\$home"/go/pkg/mod/cache >/dev/null 2>&1 || true; done'
 fi
 
 # 6. OLD /tmp FILES (older than 7 days)
-if [ "${CLEAN_OLD_TMP}" = "yes" ]; then
+if [ "${safe_clean_old_tmp}" = "yes" ]; then
   step TMP 'find /tmp -mindepth 1 -mtime +7 -exec rm -rf {} + 2>/dev/null'
 fi
 

--- a/lxc-updater.sh
+++ b/lxc-updater.sh
@@ -318,11 +318,15 @@ update_lxc() {
   # Batched Environment Detection
   # Prevents severe O(N) latency caused by repeatedly spawning Proxmox CLI ('pct exec')
   local candidates_str="${UPDATE_CANDIDATES[*]}"
+
+  # 🛡️ Sentinel Security Fix: Sanitize variable before interpolating into unquoted heredoc executed via pct exec
+  local safe_clean_tmp="${CLEAN_TMP_7_DAYS//[^a-zA-Z0-9_-]/}"
+
   # ⚡ Bolt: Replaced $(cat << EOF) with pure Bash read to prevent spawning 2 unnecessary processes per container
   local env_script
   read -r -d '' env_script << EOF || true
 # ⚡ Bolt: Batch /tmp cleanup into initial environment check to prevent spawning an extra pct process
-if [ "${CLEAN_TMP_7_DAYS}" = "yes" ]; then
+if [ "${safe_clean_tmp}" = "yes" ]; then
   find /tmp -mindepth 1 -mtime +7 -exec rm -rf {} + 2>/dev/null || true
 fi
 


### PR DESCRIPTION
🛡️ Sentinel: [CRITICAL] Fix command injection in PVE heredocs

🚨 Severity: CRITICAL
💡 Vulnerability: Configuration variables sourced from external files were interpolated directly into unquoted heredocs (`<< EOF`) which were then executed as root inside Proxmox LXC containers via `pct exec bash -c`.
🎯 Impact: If an attacker gained write access to the config file (or modified environment variables), they could supply maliciously crafted strings (e.g. `CLEAN_PKG_CACHE="yes\"; rm -rf /; #"`). Because the unquoted heredoc expands variables on the host *before* passing the script to the container, this would lead to arbitrary command execution.
🔧 Fix: Added strict regex sanitization (`[^a-zA-Z0-9_-]`) to all interpolated variables in `lxc-cleanup.sh` and `lxc-updater.sh` before they are placed into the unquoted heredoc, preventing command injection via host-side variable expansion.
✅ Verification: Tested via `bash -n` and the local `./scripts/` suite.

---
*PR created automatically by Jules for task [4078713389946823910](https://jules.google.com/task/4078713389946823910) started by @spupuz*