### PR TITLE
🎨 Palette: UX Improvements to CLI Errors and Notifications

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,4 @@
+
+## $(date +%Y-%m-%d) - Actionable Error Hints in CLI Logs
+**Learning:** Generic error messages (like symlink warnings) or state warnings (like updates available) often leave users wondering what to do next, creating friction.
+**Action:** When adding or modifying error/warning logs, always include a parenthetical actionable hint (e.g., "(Please replace it with a regular file)", "(not installed)").

--- a/lxc-cleanup.sh
+++ b/lxc-cleanup.sh
@@ -141,7 +141,7 @@ secure_source() {
   local conf_file="$1"
   if [[ ! -f "$conf_file" ]]; then return 0; fi
   if [[ -h "$conf_file" ]]; then
-    log ERROR "❌ SECURITY CRITICAL: $conf_file is a symlink. Refusing to load to prevent privilege escalation."
+    log ERROR "❌ SECURITY CRITICAL: $conf_file is a symlink. Refusing to load to prevent privilege escalation. (Please replace it with a regular file)"
     return 1
   fi
 
@@ -504,7 +504,7 @@ cleanup_lxc() {
   CT_COLOR="${SECTION_COLORS[$(( ${ctid} % ${#SECTION_COLORS[@]} ))]}"
   CT_PREFIX="[${ctid}:${ctraw}] "
 
-  log INFO "🧹 Cleaning LXC $ctid ($ctname)..."
+  log INFO "ℹ️ Cleaning LXC $ctid ($ctname)..."
 
   local usage_before
   usage_before=$(get_disk_usage "$ctid") || true
@@ -703,7 +703,7 @@ main() {
   fi
 
   report+=$'\n'
-  report+="🧹 Cleaned: ${clean_count}"$'\n'
+  report+="✅ Cleaned: ${clean_count}"$'\n'
   report+="⏭️ Excluded: ${skip_count}"$'\n'
   report+="❌ Failed: ${fail_count}"$'\n'
 

--- a/lxc-updater.sh
+++ b/lxc-updater.sh
@@ -154,7 +154,7 @@ secure_source() {
   local conf_file="$1"
   if [[ ! -f "$conf_file" ]]; then return 0; fi
   if [[ -h "$conf_file" ]]; then
-    log ERROR "❌ SECURITY CRITICAL: $conf_file is a symlink. Refusing to load to prevent privilege escalation."
+    log ERROR "❌ SECURITY CRITICAL: $conf_file is a symlink. Refusing to load to prevent privilege escalation. (Please replace it with a regular file)"
     return 1
   fi
 

--- a/pve-update-notifier.sh
+++ b/pve-update-notifier.sh
@@ -82,7 +82,7 @@ secure_source() {
   local conf_file="$1"
   if [[ ! -f "$conf_file" ]]; then return 0; fi
   if [[ -h "$conf_file" ]]; then
-    log ERROR "❌ SECURITY CRITICAL: $conf_file is a symlink. Refusing to load to prevent privilege escalation."
+    log ERROR "❌ SECURITY CRITICAL: $conf_file is a symlink. Refusing to load to prevent privilege escalation. (Please replace it with a regular file)"
     return 1
   fi
 
@@ -400,7 +400,7 @@ if apt-get update -o Acquire::http::Timeout=10 -o Acquire::ftp::Timeout=10 -o Ac
     if [ -z "$HOST_UPDATES_CLEAN" ] || [ "$HOST_UPDATES_CLEAN" -eq 0 ]; then
         REPORT+="🖥️ *Proxmox Host*: ✅ Up to date"$'\n'
     else
-        REPORT+="🖥️ *Proxmox Host*: ⚠️ $HOST_UPDATES_CLEAN updates available"$'\n'
+        REPORT+="🖥️ *Proxmox Host*: ⚠️ $HOST_UPDATES_CLEAN updates available (not installed)"$'\n'
     fi
 else
     REPORT+="🖥️ *Proxmox Host*: ❌ Error during check (Check network or apt locks)"$'\n'
@@ -464,7 +464,7 @@ if $IS_PVE_HOST; then
               elif [ "$LXC_UPD_RESULT" = "ERROR" ]; then
                   RESULT_LINE="• ID $CTID ($CTNAME): ❌ Error checking updates (Container offline or timed out)"
                elif [ ! -z "$LXC_UPD_RESULT_CLEAN" ] && [ "$LXC_UPD_RESULT_CLEAN" -gt 0 ] 2>/dev/null; then
-                  RESULT_LINE="• ID $CTID ($CTNAME): ⚠️ *$LXC_UPD_RESULT_CLEAN* updates available"
+                  RESULT_LINE="• ID $CTID ($CTNAME): ⚠️ *$LXC_UPD_RESULT_CLEAN* updates available (not installed)"
               else
                   RESULT_LINE="• ID $CTID ($CTNAME): ✅ Up to date"
               fi

--- a/system-update-notifier.sh
+++ b/system-update-notifier.sh
@@ -58,7 +58,7 @@ secure_source() {
   local conf_file="$1"
   if [[ ! -f "$conf_file" ]]; then return 0; fi
   if [[ -h "$conf_file" ]]; then
-    log ERROR "❌ SECURITY CRITICAL: $conf_file is a symlink. Refusing to load to prevent privilege escalation."
+    log ERROR "❌ SECURITY CRITICAL: $conf_file is a symlink. Refusing to load to prevent privilege escalation. (Please replace it with a regular file)"
     return 1
   fi
 


### PR DESCRIPTION
🎨 Palette: Add actionable hints to generic error messages and standardize emoji prefixes

💡 What:
- Appended "(Please replace it with a regular file)" to the `SECURITY CRITICAL: $conf_file is a symlink` error across `lxc-cleanup.sh`, `lxc-updater.sh`, `pve-update-notifier.sh`, and `system-update-notifier.sh`.
- Appended "(not installed)" to the "updates available" warnings in `pve-update-notifier.sh` so users aren't confused about whether the notifier applied the updates.
- Standardized the emoji prefixes in `lxc-cleanup.sh` to use `ℹ️` (info) when starting an operation and `✅` (success) when a container is cleaned, replacing the overused `🧹` emoji.

🎯 Why: 
Generic error messages and ambiguous statuses (like "updates available") create user friction. Adding actionable hints directly in the CLI output helps users resolve issues faster. Using standard emoji prefixes (✅, ℹ️, ❌, ⚠️) improves scannability across log files and Telegram notifications.

♿ Accessibility:
Clear, actionable error states improve cognitive accessibility for users parsing terminal output.

---
*PR created automatically by Jules for task [7227705011881290329](https://jules.google.com/task/7227705011881290329) started by @spupuz*