### PR TITLE
🎨 Palette: Add missing CLI visual feedback for skipped and completed container actions

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2025-01-20 - Add missing CLI feedback for skipped and completed actions
+**Learning:** Background processes that emit outputs exclusively via buffered variables for notification payloads (like Telegram summaries) leave the CLI interface silent. This violates empty state and visual feedback rules, as the CLI consumer sees silent skipping or abrupt ending of actions without clear resolution states.
+**Action:** When performing container operations, mirror critical payload states (like `⏭️ Excluded` or final `✅/❌/⚠️` status strings) to standard `log()` calls for immediate and contextual CLI scannability.

--- a/lxc-cleanup.sh
+++ b/lxc-cleanup.sh
@@ -634,6 +634,7 @@ main() {
 
       if is_excluded "$ctid"; then
         echo "• ${ctid}: ⏭️ Excluded" > "$tmp_dir/$ctid"
+        log INFO "⏭️ LXC $ctid ($ctraw) excluded"
         continue
       fi
 

--- a/lxc-updater.sh
+++ b/lxc-updater.sh
@@ -578,10 +578,12 @@ EOF
 
   # Formatting result for report
   local final_line=""
+  local log_level="INFO"
   if [[ "$app_updated" == "yes" && "$pkg_updated" == "yes" ]]; then
     final_line="• $ctid ($ctname): ✅ App + OS Updated"
   elif [[ "$app_updated" == "yes" ]]; then
     final_line="• $ctid ($ctname): ⚠️ App Updated (OS update skipped/failed)"
+    log_level="WARN"
   elif [[ "$pkg_updated" == "yes" ]]; then
     final_line="• $ctid ($ctname): ✅ OS Updated (No app script found)"
   else
@@ -592,13 +594,17 @@ EOF
     safe_error_msg="${safe_error_msg//\]/\\]}"
     safe_error_msg="${safe_error_msg//\`/\\\`}"
     final_line="• $ctid ($ctname): ❌ Update failed: ${safe_error_msg}"
+    log_level="ERROR"
   fi
 
   echo "$final_line"
   if [[ -n "$netbird_info" ]]; then
     echo "$netbird_info"
   fi
-  log DEBUG "update_lxc finished for $ctid ($ctname)"
+
+  log "$log_level" "${final_line#• $ctid ($ctname): }"
+
+  log DEBUG "update_lxc finished for $ctid ($ctraw)"
   return 0
 }
 
@@ -679,6 +685,7 @@ main() {
 
       if is_excluded "$ctid"; then
         echo "• ${ctid}: ⏭️ Excluded" > "$tmp_dir/$ctid"
+        log INFO "⏭️ LXC $ctid ($ctraw) excluded"
         continue
       fi
 


### PR DESCRIPTION
💡 What: Added explicit `log INFO` lines for excluded containers and added a final status `log` for completed updates in `lxc-updater.sh`.
🎯 Why: Prevents silent failures/skips in the CLI console output when results are buffered for Telegram. Provides immediate visual resolution state.
📸 Before/After: Before, excluded containers generated no CLI output, and updated containers ended silently. After, they emit `[INFO] ⏭️ LXC 100 (test) excluded` and `[INFO] ✅ App + OS Updated` respectively.
♿ Accessibility: Improves CLI scannability and prevents user confusion about the current progress/state of the script.

---
*PR created automatically by Jules for task [15376147027073510590](https://jules.google.com/task/15376147027073510590) started by @spupuz*