### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix temporary file resource leak in mktemp usage

### DIFF
--- a/lxc-cleanup.sh
+++ b/lxc-cleanup.sh
@@ -30,7 +30,7 @@
 
 set -Eeuo pipefail
 
-SCRIPT_VERSION="v0.10.1"
+SCRIPT_VERSION="v0.10.2"
 
 # --- LOGGING ---
 LOG_STDOUT="${LOG_STDOUT:-yes}" # Set to "no" to disable console output (useful for cron)
@@ -313,6 +313,7 @@ Run \`bash ${script_name} --update\` to install."
 
     local tmp_file
     tmp_file=$(mktemp "/tmp/${name}.XXXXXX") || { log ERROR "❌ Failed to create temporary file (Check /tmp permissions or disk space)"; continue; }
+    CLEANUP_PATHS+=("$tmp_file") # 🛡️ Sentinel Security Fix: Register tmp_file for cleanup to prevent resource exhaustion
 
     if curl --proto '=https' --tlsv1.2 -sL --connect-timeout 5 --max-time 30 \
       -o "$tmp_file" "$repo_base/$name"; then

--- a/lxc-updater.sh
+++ b/lxc-updater.sh
@@ -24,7 +24,7 @@
 
 set -Eeuo pipefail
 
-SCRIPT_VERSION="v0.10.1"
+SCRIPT_VERSION="v0.10.2"
 
 # --- LOGGING ---
 LOG_STDOUT="${LOG_STDOUT:-yes}" # Set to "no" to disable console output (useful for cron)
@@ -333,6 +333,7 @@ Run \`bash ${script_name} --update\` to install."
 
     local tmp_file
     tmp_file=$(mktemp "/tmp/${name}.XXXXXX") || { log ERROR "❌ Failed to create temporary file (Check /tmp permissions or disk space)"; continue; }
+    CLEANUP_PATHS+=("$tmp_file") # 🛡️ Sentinel Security Fix: Register tmp_file for cleanup to prevent resource exhaustion
 
     if curl --proto '=https' --tlsv1.2 -sL --connect-timeout 5 --max-time 30 \
       -o "$tmp_file" "$repo_base/$name"; then

--- a/pve-update-notifier.sh
+++ b/pve-update-notifier.sh
@@ -14,7 +14,7 @@
 # Use this script at your own risk. The authors are not responsible for any
 # data loss, system instability, or service downtime caused by running it.
 
-SCRIPT_VERSION="v0.10.1"
+SCRIPT_VERSION="v0.10.2"
 
 # Add this path variable so Cron can find the required system commands
 export PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
@@ -250,6 +250,7 @@ Run \`bash ${script_name} --update\` to install."
 
     local tmp_file
     tmp_file=$(mktemp "/tmp/${name}.XXXXXX") || { log ERROR "❌ Failed to create temporary file (Check /tmp permissions or disk space)"; continue; }
+    CLEANUP_PATHS+=("$tmp_file") # 🛡️ Sentinel Security Fix: Register tmp_file for cleanup to prevent resource exhaustion
 
     if curl --proto '=https' --tlsv1.2 -sL --connect-timeout 5 --max-time 30 \
       -o "$tmp_file" "$repo_base/$name"; then

--- a/system-update-notifier.sh
+++ b/system-update-notifier.sh
@@ -2,7 +2,7 @@
 # System Update Notifier
 # Updates the host system via apt and sends a Telegram notification.
 
-SCRIPT_VERSION="v0.10.1"
+SCRIPT_VERSION="v0.10.2"
 
 export PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 
@@ -208,6 +208,7 @@ Run \`bash ${script_name} --update\` to install."
 
     local tmp_file
     tmp_file=$(mktemp "/tmp/${name}.XXXXXX") || { log ERROR "❌ Failed to create temporary file (Check /tmp permissions or disk space)"; continue; }
+    CLEANUP_PATHS+=("$tmp_file") # 🛡️ Sentinel Security Fix: Register tmp_file for cleanup to prevent resource exhaustion
 
     if curl --proto '=https' --tlsv1.2 -sL --connect-timeout 5 --max-time 30 \
       -o "$tmp_file" "$repo_base/$name"; then


### PR DESCRIPTION
🛡️ Sentinel: [MEDIUM] Fix temporary file resource leak in mktemp usage

- 🚨 Severity: MEDIUM
- 💡 Vulnerability: Unmanaged temporary files created via `mktemp` (specifically those for downloading updates via `curl`) were left on disk if the script exited abruptly (e.g., failed `curl`, `set -e` triggers, or SIGINT), due to not being registered with the `EXIT` trap immediately upon creation. This could eventually lead to disk exhaustion or localized denial of service (filling `/tmp` or predictable inodes).
- 🎯 Impact: Potential resource exhaustion of `/tmp` if update checks consistently fail and leave dangling files over time.
- 🔧 Fix: Immediately append newly created temporary files to the globally managed `CLEANUP_PATHS` array explicitly registered in the global `trap cleanup EXIT`. Do not rely solely on inline `rm -f` for robust resource management. Also bumps the patch version (v0.10.1 -> v0.10.2).
- ✅ Verification: Run `bash -n *.sh` to verify syntax and trigger a manual update with simulated interrupt to ensure cleanup.

---
*PR created automatically by Jules for task [14215217049162460130](https://jules.google.com/task/14215217049162460130) started by @spupuz*