### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Markdown Injection DoS in Telegram Payload

### DIFF
--- a/pve-update-notifier.sh
+++ b/pve-update-notifier.sh
@@ -357,6 +357,15 @@ get_lxc_disk_summary() {
     else
       label="$mp"
     fi
+
+    # 🛡️ Sentinel Security Fix: Escape Markdown control characters in mount point path
+    # to prevent Telegram API injection DoS when generating the disk usage report
+    label="${label//_/\\_}"
+    label="${label//\*/\\*}"
+    label="${label//\[/\\[}"
+    label="${label//\]/\\]}"
+    label="${label//\`/\\\`}"
+
     if (( pct >= DISK_USAGE_THRESHOLD )); then
       lines+=("      🚨 *${label}*: ${pct}% (>${DISK_USAGE_THRESHOLD}%) (${human_used}/${human_size})")
     else


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: Unsanitized disk mount point paths (`label`) retrieved from container configurations were directly interpolated into a Telegram Markdown notification payload.
🎯 Impact: If an attacker or a standard deployment uses labels containing Markdown formatting characters (such as `_`, like in the default `local_lvm`), the Telegram API rejects the payload due to an unbalanced formatting error. This causes a complete Denial of Service (DoS) for the notification script, masking any alarms.
🔧 Fix: Added bash string replacement logic (`${label//_/\\_}`) to explicitly escape Markdown control characters (`_`, `*`, `[`, `]`, `` ` ``) before adding the label to the notification report.
✅ Verification: Ran testing scripts and a syntax check on `pve-update-notifier.sh`. The characters are safely escaped for Telegram.

---
*PR created automatically by Jules for task [89726655938922103](https://jules.google.com/task/89726655938922103) started by @spupuz*