### PR TITLE
🎨 Palette: Align visual error states with semantic levels in cleanup

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-15 - Aligning Visual Error States with Semantic Levels
+**Learning:** When using logging wrappers that automatically prefix or output based on log levels (e.g., `log ERROR`), embedding a mismatching visual emoji (like `⚠️`) inside the error payload creates cognitive dissonance for the user. Furthermore, generic error states without actionable guidance cause friction.
+**Action:** Always ensure that CLI payloads match their semantic log level visually (e.g. `❌` with `ERROR`, `⚠️` with `WARN`), and append actionable hints to the end of the error string (e.g., `(Check container status or network)`) so users immediately know the next step.

--- a/lxc-cleanup.sh
+++ b/lxc-cleanup.sh
@@ -529,7 +529,7 @@ cleanup_lxc() {
 
   if [[ "$rc" -ne 0 ]]; then
     echo "• ${ctid} (${ctname}): ❌ Cleanup failed (Check container status or network)"
-    log WARN "⚠️ LXC $ctid ($ctname) cleanup failed"
+    log ERROR "❌ LXC $ctid ($ctname) cleanup failed (Check container status or network)"
     return 1
   fi
 


### PR DESCRIPTION
🎨 Palette: Align visual error states with semantic levels

💡 What: Changed the log output for a failed LXC cleanup in `lxc-cleanup.sh` from a `log WARN` with a `⚠️` emoji to a `log ERROR` with a `❌` emoji.
🎯 Why: Using a mismatched warning log level for a failure state creates cognitive dissonance. Aligning the visual emoji (`❌`) with the semantic severity (`ERROR`) improves log readability. Actionable guidance was also appended to the error payload.
📸 Before/After: Visual change in CLI log strings.
♿ Accessibility: Improved error scannability for administrators monitoring automated scripts.

---
*PR created automatically by Jules for task [1379372829856561607](https://jules.google.com/task/1379372829856561607) started by @spupuz*