### PR TITLE
⚡ Bolt: optimize human_readable and step_label_name to prevent subshell forks

### DIFF
--- a/lxc-cleanup.sh
+++ b/lxc-cleanup.sh
@@ -372,24 +372,30 @@ is_excluded() {
   return 1
 }
 
+# ⚡ Bolt: Allow optional output variable assignment to avoid subshell forks
 human_readable() {
-  local kb="$1"
+  local kb="$1" outvar="${2:-}" outval
   if (( kb < 1024 )); then
-    echo "${kb}K"
+    outval="${kb}K"
   elif (( kb < 1048576 )); then
     local mb_tenths=$(( (kb * 10 + 512) / 1024 ))
     if (( mb_tenths % 10 == 0 )); then
-      echo "$(( mb_tenths / 10 ))M"
+      outval="$(( mb_tenths / 10 ))M"
     else
-      echo "$(( mb_tenths / 10 )).$(( mb_tenths % 10 ))M"
+      outval="$(( mb_tenths / 10 )).$(( mb_tenths % 10 ))M"
     fi
   else
     local gb_tenths=$(( (kb * 10 + 524288) / 1048576 ))
     if (( gb_tenths % 10 == 0 )); then
-      echo "$(( gb_tenths / 10 ))G"
+      outval="$(( gb_tenths / 10 ))G"
     else
-      echo "$(( gb_tenths / 10 )).$(( gb_tenths % 10 ))G"
+      outval="$(( gb_tenths / 10 )).$(( gb_tenths % 10 ))G"
     fi
+  fi
+  if [[ -n "$outvar" ]]; then
+    printf -v "$outvar" "%s" "$outval"
+  else
+    echo "$outval"
   fi
 }
 
@@ -496,17 +502,24 @@ EOF
 }
 
 # Friendly name for a cleanup step label, used in logs and reports
+# ⚡ Bolt: Allow optional output variable assignment to avoid subshell forks
 step_label_name() {
-  case "$1" in
-    PKG_CACHE) echo "Pkg cache" ;;
-    JOURNAL) echo "Logs (journald)" ;;
-    DOCKER) echo "Docker images/build" ;;
-    DOCKER_VOLUMES) echo "Docker volumes" ;;
-    DOCKER_TMP) echo "Docker /tmp" ;;
-    USER_CACHE) echo "User caches" ;;
-    TMP) echo "Old /tmp" ;;
-    *) echo "$1" ;;
+  local label="$1" outvar="${2:-}" outval
+  case "$label" in
+    PKG_CACHE) outval="Pkg cache" ;;
+    JOURNAL) outval="Logs (journald)" ;;
+    DOCKER) outval="Docker images/build" ;;
+    DOCKER_VOLUMES) outval="Docker volumes" ;;
+    DOCKER_TMP) outval="Docker /tmp" ;;
+    USER_CACHE) outval="User caches" ;;
+    TMP) outval="Old /tmp" ;;
+    *) outval="$label" ;;
   esac
+  if [[ -n "$outvar" ]]; then
+    printf -v "$outvar" "%s" "$outval"
+  else
+    echo "$outval"
+  fi
 }
 
 cleanup_lxc() {
@@ -543,11 +556,14 @@ cleanup_lxc() {
         local label="${line%%:*}"
         freed="${line##*:}"
         [[ "$freed" =~ ^-?[0-9]+$ ]] || freed=0
-        local fname
-        fname="$(step_label_name "$label")"
+        local fname hr_freed
+        # ⚡ Bolt: Replace command substitution with pure bash assignment
+        step_label_name "$label" fname
         if (( freed > 0 )); then
-          step_desc+="      ✅ ${fname}: freed $(human_readable "$freed")"$'\n'
-          log INFO "✅  -> ${fname}: freed $(human_readable "$freed")"
+          # ⚡ Bolt: Evaluate human_readable once and avoid subshells
+          human_readable "$freed" hr_freed
+          step_desc+="      ✅ ${fname}: freed ${hr_freed}"$'\n'
+          log INFO "✅  -> ${fname}: freed ${hr_freed}"
         else
           log INFO "ℹ️  -> ${fname}: nothing to free"
         fi
@@ -561,10 +577,12 @@ cleanup_lxc() {
 
   (( freed_kb > 0 )) || freed_kb=0
 
-  local result_line
+  local result_line hr_total
   if (( freed_kb > 0 )); then
-    result_line="• ${ctid} (${ctname}): ✅ Freed $(human_readable "$freed_kb")"
-    log INFO "✅ LXC $ctid ($ctname) cleaned (freed $(human_readable "$freed_kb"))"
+    # ⚡ Bolt: Evaluate human_readable once and avoid subshells
+    human_readable "$freed_kb" hr_total
+    result_line="• ${ctid} (${ctname}): ✅ Freed ${hr_total}"
+    log INFO "✅ LXC $ctid ($ctname) cleaned (freed ${hr_total})"
   else
     result_line="• ${ctid} (${ctname}): ✅ Cleaned (nothing to free)"
     log INFO "✅ LXC $ctid ($ctname) cleaned (nothing to free)"


### PR DESCRIPTION
💡 What: Refactored `human_readable` and `step_label_name` in `lxc-cleanup.sh` to optionally accept an output variable name and assign the result using pure Bash `printf -v` instead of relying on command substitution (`$(func)`).
🎯 Why: Command substitutions spawn a subshell process for every evaluation. In `cleanup_lxc`, `human_readable` and `step_label_name` are called inside loops up to 23 times per container, generating severe O(N) process fork overhead.
📊 Impact: Prevents up to 23 subshell forks per container, potentially saving over 1,000 process forks in a typical 40-50 container Proxmox environment, significantly reducing CPU context switching and execution time.
🔬 Measurement: Verified locally using scratch test variables, executed standard script test suite successfully. Impact is measurable via `strace` or by observing process counts during cleanup execution.

---
*PR created automatically by Jules for task [3382510958239263123](https://jules.google.com/task/3382510958239263123) started by @spupuz*