### PR TITLE
🎨 Palette: Add real-time log mirroring for background container cleanup jobs

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-15 - Real-time CLI Feedback for Background Jobs
+**Learning:** Background subshells silently buffer all output until completion. Users need immediate CLI feedback when processing many items concurrently to prevent the appearance of a hanging script and improve scannability.
+**Action:** Added file descriptor duplication (exec 3>&1) and immediate payload mirroring for container outcomes in lxc-cleanup.sh to match the pattern in lxc-updater.sh, providing immediate visual feedback and clear resolution states for the CLI consumer.

--- a/lxc-cleanup.sh
+++ b/lxc-cleanup.sh
@@ -622,6 +622,7 @@ main() {
     local pending=0
     local -A job_pid=()
 
+    exec 3>&1
     for item in "${lxc_list[@]}"; do
       [[ -z "$item" ]] && continue
 
@@ -652,6 +653,19 @@ main() {
         section_banner "$ctid" "$ctraw"
         local result
         result=$(cleanup_lxc "$ctid" "$ctname" "$ctraw")
+        # Mirror container outcome immediately (bypass subshell stdout capture)
+        local first_line="${result%%$'\n'*}"
+        if [[ "$first_line" == *"✅"* ]]; then
+          log INFO "${first_line#* ($ctname): }" >&3
+        elif [[ "$first_line" == *"⚠️"* ]]; then
+          log WARN "${first_line#* ($ctname): }" >&3
+        elif [[ "$first_line" == *"❌"* ]]; then
+          log ERROR "${first_line#* ($ctname): }" >&3
+        elif [[ "$first_line" == *"⏭️"* ]]; then
+          log INFO "${first_line#* ($ctname): }" >&3
+        else
+          log INFO "${first_line#* ($ctname): }" >&3
+        fi
         echo "$result" > "$tmp_dir/$ctid"
         section_footer "$ctid" "$ctraw"
       ) >"$tmp_dir/$ctid.log" 2>&1 &
@@ -669,6 +683,7 @@ main() {
     # ⚡ Bolt: Print each container's complete output as one block when it
     # finishes. A job only counts as done once it has been reaped by wait -n,
     # which also guarantees its buffer file is fully flushed and complete.
+    exec 3>&-
     local printed=0
     while (( printed < pending )); do
       wait -n || true


### PR DESCRIPTION
💡 What: Added real-time log mirroring for container cleanup jobs in `lxc-cleanup.sh`.
🎯 Why: Because the background subshells buffer all output until completion, the CLI appears to hang while containers are being cleaned. This provides immediate visual feedback.
♿ Accessibility/UX: Greatly improves script scannability and user feedback without breaking headless/cron compatibility.

---
*PR created automatically by Jules for task [16062328519129429954](https://jules.google.com/task/16062328519129429954) started by @spupuz*