### PR TITLE
🎨 Palette: Mirror container outcome immediately in lxc-cleanup.sh

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-08-22 - Bash Background Job Logging UX Pattern
+**Learning:** When executing background jobs with output buffered to files via subshells in Bash, real-time visual feedback is lost, making the CLI interface appear to hang during long-running parallel tasks.
+**Action:** Duplicating the standard output to a new file descriptor (e.g., `exec 3>&1`) before the loop allows specific subshell commands to write directly back to the terminal (e.g., `>&3`) in real-time, providing immediate state visibility while preserving the overall output buffering.

--- a/lxc-cleanup.sh
+++ b/lxc-cleanup.sh
@@ -622,6 +622,7 @@ main() {
     local pending=0
     local -A job_pid=()
 
+    exec 3>&1
     for item in "${lxc_list[@]}"; do
       [[ -z "$item" ]] && continue
 
@@ -652,6 +653,17 @@ main() {
         section_banner "$ctid" "$ctraw"
         local result
         result=$(cleanup_lxc "$ctid" "$ctname" "$ctraw")
+        # Mirror container outcome immediately (bypass subshell stdout capture)
+        local first_line="${result%%$'\n'*}"
+        if [[ "$first_line" == *"✅"* ]]; then
+          log INFO "${first_line#* ($ctname): }" >&3
+        elif [[ "$first_line" == *"⚠️"* ]]; then
+          log WARN "${first_line#* ($ctname): }" >&3
+        elif [[ "$first_line" == *"❌"* ]]; then
+          log ERROR "${first_line#* ($ctname): }" >&3
+        else
+          log INFO "${first_line#* ($ctname): }" >&3
+        fi
         echo "$result" > "$tmp_dir/$ctid"
         section_footer "$ctid" "$ctraw"
       ) >"$tmp_dir/$ctid.log" 2>&1 &
@@ -669,6 +681,7 @@ main() {
     # ⚡ Bolt: Print each container's complete output as one block when it
     # finishes. A job only counts as done once it has been reaped by wait -n,
     # which also guarantees its buffer file is fully flushed and complete.
+    exec 3>&-
     local printed=0
     while (( printed < pending )); do
       wait -n || true

--- a/scripts/test_ux_mirrors.sh
+++ b/scripts/test_ux_mirrors.sh
@@ -28,4 +28,9 @@ if ! grep -F 'log ERROR "${first_line#* ($ctname): }" >&3' lxc-updater.sh; then
     false
 fi
 
+if ! grep -F 'log ERROR "${first_line#* ($ctname): }" >&3' lxc-cleanup.sh; then
+    echo "❌ Error: lxc-cleanup.sh is missing LXC UX mirror"
+    false
+fi
+
 echo "✅ All UX mirror tests passed!"


### PR DESCRIPTION
💡 What: Added the UX mirror pattern (`exec 3>&1` and `>&3`) to the concurrent subshell execution in `lxc-cleanup.sh` to output container results (✅, ⚠️, ❌) immediately to the CLI console as they finish, rather than waiting for all jobs to complete.
🎯 Why: Long-running background jobs with buffered outputs cause the CLI to hang silently. Surfacing the final status of each container in real-time gives users immediate visual feedback and improves scannability.
📸 Before/After: Before, `lxc-cleanup.sh` would only print output after a container's wait completed. After, a `log INFO` string appears immediately as the specific container's subshell finishes.
♿ Accessibility: Improves CLI feedback loop for users monitoring large automated runs.

---
*PR created automatically by Jules for task [5230704947211818248](https://jules.google.com/task/5230704947211818248) started by @spupuz*