### PR TITLE
⚡ Bolt: Optimize helper functions in lxc-cleanup.sh to use pure Bash printf -v

### DIFF
--- a/lxc-cleanup.sh
+++ b/lxc-cleanup.sh
@@ -372,24 +372,33 @@ is_excluded() {
   return 1
 }
 
+# ⚡ Bolt: Allow optional output variable parameter to prevent subshell spawning
 human_readable() {
   local kb="$1"
+  local outvar="${2:-}"
+  local result=""
   if (( kb < 1024 )); then
-    echo "${kb}K"
+    result="${kb}K"
   elif (( kb < 1048576 )); then
     local mb_tenths=$(( (kb * 10 + 512) / 1024 ))
     if (( mb_tenths % 10 == 0 )); then
-      echo "$(( mb_tenths / 10 ))M"
+      result="$(( mb_tenths / 10 ))M"
     else
-      echo "$(( mb_tenths / 10 )).$(( mb_tenths % 10 ))M"
+      result="$(( mb_tenths / 10 )).$(( mb_tenths % 10 ))M"
     fi
   else
     local gb_tenths=$(( (kb * 10 + 524288) / 1048576 ))
     if (( gb_tenths % 10 == 0 )); then
-      echo "$(( gb_tenths / 10 ))G"
+      result="$(( gb_tenths / 10 ))G"
     else
-      echo "$(( gb_tenths / 10 )).$(( gb_tenths % 10 ))G"
+      result="$(( gb_tenths / 10 )).$(( gb_tenths % 10 ))G"
     fi
+  fi
+
+  if [[ -n "$outvar" ]]; then
+    printf -v "$outvar" "%s" "$result"
+  else
+    echo "$result"
   fi
 }
 
@@ -496,17 +505,26 @@ EOF
 }
 
 # Friendly name for a cleanup step label, used in logs and reports
+# ⚡ Bolt: Allow optional output variable parameter to prevent subshell spawning
 step_label_name() {
+  local outvar="${2:-}"
+  local result=""
   case "$1" in
-    PKG_CACHE) echo "Pkg cache" ;;
-    JOURNAL) echo "Logs (journald)" ;;
-    DOCKER) echo "Docker images/build" ;;
-    DOCKER_VOLUMES) echo "Docker volumes" ;;
-    DOCKER_TMP) echo "Docker /tmp" ;;
-    USER_CACHE) echo "User caches" ;;
-    TMP) echo "Old /tmp" ;;
-    *) echo "$1" ;;
+    PKG_CACHE) result="Pkg cache" ;;
+    JOURNAL) result="Logs (journald)" ;;
+    DOCKER) result="Docker images/build" ;;
+    DOCKER_VOLUMES) result="Docker volumes" ;;
+    DOCKER_TMP) result="Docker /tmp" ;;
+    USER_CACHE) result="User caches" ;;
+    TMP) result="Old /tmp" ;;
+    *) result="$1" ;;
   esac
+
+  if [[ -n "$outvar" ]]; then
+    printf -v "$outvar" "%s" "$result"
+  else
+    echo "$result"
+  fi
 }
 
 cleanup_lxc() {
@@ -544,10 +562,13 @@ cleanup_lxc() {
         freed="${line##*:}"
         [[ "$freed" =~ ^-?[0-9]+$ ]] || freed=0
         local fname
-        fname="$(step_label_name "$label")"
+        # ⚡ Bolt: Use output variable instead of subshell
+        step_label_name "$label" fname
         if (( freed > 0 )); then
-          step_desc+="      ✅ ${fname}: freed $(human_readable "$freed")"$'\n'
-          log INFO "✅  -> ${fname}: freed $(human_readable "$freed")"
+          local hr_freed
+          human_readable "$freed" hr_freed
+          step_desc+="      ✅ ${fname}: freed ${hr_freed}"$'\n'
+          log INFO "✅  -> ${fname}: freed ${hr_freed}"
         else
           log INFO "ℹ️  -> ${fname}: nothing to free"
         fi
@@ -563,8 +584,11 @@ cleanup_lxc() {
 
   local result_line
   if (( freed_kb > 0 )); then
-    result_line="• ${ctid} (${ctname}): ✅ Freed $(human_readable "$freed_kb")"
-    log INFO "✅ LXC $ctid ($ctname) cleaned (freed $(human_readable "$freed_kb"))"
+    local hr_freed_total
+    # ⚡ Bolt: Use output variable instead of subshell
+    human_readable "$freed_kb" hr_freed_total
+    result_line="• ${ctid} (${ctname}): ✅ Freed ${hr_freed_total}"
+    log INFO "✅ LXC $ctid ($ctname) cleaned (freed ${hr_freed_total})"
   else
     result_line="• ${ctid} (${ctname}): ✅ Cleaned (nothing to free)"
     log INFO "✅ LXC $ctid ($ctname) cleaned (nothing to free)"


### PR DESCRIPTION
💡 What: Refactored `human_readable` and `step_label_name` in `lxc-cleanup.sh` to accept an optional output variable and updated loop usage to avoid subshells.
🎯 Why: `$(human_readable "$freed")` spawns a subshell process for every calculation inside every container cleanup loop. Process forks in Bash are heavy, causing cumulative latency across environments with many LXCs.
📊 Impact: Prevents spawning 2+ external processes (subshells) per container, speeding up script execution times.
🔬 Measurement: Verified functionality by manually assigning variables to both functions and ensuring the fallback (echo) still works. Also verified the UX tests pass correctly.

---
*PR created automatically by Jules for task [2980056709625619641](https://jules.google.com/task/2980056709625619641) started by @spupuz*