### PR TITLE
🎨 Palette: Add explicit CLI logging for empty container states

### DIFF
--- a/lxc-cleanup.sh
+++ b/lxc-cleanup.sh
@@ -607,6 +607,7 @@ main() {
   report+="*🧽 LXC Containers Status:*"$'\n'
 
   if [[ ${#lxc_list[@]} -eq 0 ]]; then
+    log INFO "⏭️ No running containers found."
     report+="• ⏭️ No running containers found."$'\n'
   else
     # Disable immediate exit to ensure the loop continues for all containers

--- a/lxc-updater.sh
+++ b/lxc-updater.sh
@@ -678,6 +678,7 @@ main() {
   log DEBUG "Detected ${#lxc_list[@]} running containers: ${lxc_list[*]:-none}"
 
   if [[ ${#lxc_list[@]} -eq 0 ]]; then
+    log INFO "⏭️ No running containers found."
     report+="• ⏭️ No running containers found."$'\n'
   else
     # Disable immediate exit to ensure the loop continues for all containers

--- a/pve-update-notifier.sh
+++ b/pve-update-notifier.sh
@@ -432,6 +432,7 @@ if $IS_PVE_HOST; then
   mapfile -t lxc_list < <(pct list | awk 'NR>1 && $2=="running" {print $1 ":" $NF}')
 
   if [ ${#lxc_list[@]} -eq 0 ]; then
+      log INFO "⏭️ No running containers found."
       REPORT+="• ⏭️ No running containers found"$'\n'
   else
       # ⚡ Bolt: Use a temporary directory to store bounded concurrent execution results


### PR DESCRIPTION
Added missing CLI log output for the 'no running containers found' empty state in all 3 relevant scripts (`lxc-cleanup.sh`, `lxc-updater.sh`, and `pve-update-notifier.sh`) for better CLI visibility.

---
*PR created automatically by Jules for task [10943193196544713786](https://jules.google.com/task/10943193196544713786) started by @spupuz*