### PR TITLE
🎨 Palette: Add CLI Logging for Empty Container States

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,4 @@
+# UX Enhancement Check
+## 2026-08-26 - Add CLI Logging for Empty Container States
+**Learning:** Missing CLI logs for empty states leave users hanging without visual feedback. Always mirroring remote payload states (like empty lists) to standard log output prevents the CLI execution from appearing silent or unresponsive, which is crucial for scannability and clear resolution states.
+**Action:** Always provide explicit CLI logging for empty states alongside updating remote payload variables (e.g., Telegram reports).

--- a/lxc-cleanup.sh
+++ b/lxc-cleanup.sh
@@ -607,6 +607,7 @@ main() {
   report+="*🧽 LXC Containers Status:*"$'\n'
 
   if [[ ${#lxc_list[@]} -eq 0 ]]; then
+    log INFO "⏭️ No running containers found."
     report+="• ⏭️ No running containers found."$'\n'
   else
     # Disable immediate exit to ensure the loop continues for all containers

--- a/lxc-updater.sh
+++ b/lxc-updater.sh
@@ -678,6 +678,7 @@ main() {
   log DEBUG "Detected ${#lxc_list[@]} running containers: ${lxc_list[*]:-none}"
 
   if [[ ${#lxc_list[@]} -eq 0 ]]; then
+    log INFO "⏭️ No running containers found."
     report+="• ⏭️ No running containers found."$'\n'
   else
     # Disable immediate exit to ensure the loop continues for all containers

--- a/pve-update-notifier.sh
+++ b/pve-update-notifier.sh
@@ -432,6 +432,7 @@ if $IS_PVE_HOST; then
   mapfile -t lxc_list < <(pct list | awk 'NR>1 && $2=="running" {print $1 ":" $NF}')
 
   if [ ${#lxc_list[@]} -eq 0 ]; then
+      log INFO "⏭️ No running containers found."
       REPORT+="• ⏭️ No running containers found"$'\n'
   else
       # ⚡ Bolt: Use a temporary directory to store bounded concurrent execution results


### PR DESCRIPTION
💡 What
Added explicit `log INFO "⏭️ No running containers found."` calls in the three LXC scripts right before appending the same message to the remote payload (`report` or `REPORT`).

🎯 Why
Previously, when the script didn't find any running containers, the execution would silently finish its LXC step by appending the message to the report string but skipping the standard `log()` output. This leaves the user running the command manually without visual feedback, contrary to the codebase UX standards.

📸 Before/After
*Before*: Script silently skips and finishes the LXC step.
*After*: Terminal outputs: `2026-08-26 18:55:50 [INFO] ⏭️ No running containers found.`

♿ Accessibility
Improves CLI scannability and prevents user confusion from silent execution states.

---
*PR created automatically by Jules for task [8386849512020353503](https://jules.google.com/task/8386849512020353503) started by @spupuz*