### PR TITLE
🎨 Palette: Add explicit CLI logging for empty container states

### DIFF
--- a/lxc-cleanup.sh
+++ b/lxc-cleanup.sh
@@ -30,7 +30,7 @@
 
 set -Eeuo pipefail
 
-SCRIPT_VERSION="v0.10.8"
+SCRIPT_VERSION="v0.10.9"
 
 # --- LOGGING ---
 LOG_STDOUT="${LOG_STDOUT:-yes}" # Set to "no" to disable console output (useful for cron)
@@ -607,6 +607,7 @@ main() {
   report+="*🧽 LXC Containers Status:*"$'\n'
 
   if [[ ${#lxc_list[@]} -eq 0 ]]; then
+    log INFO "⏭️ No running containers found."
     report+="• ⏭️ No running containers found."$'\n'
   else
     # Disable immediate exit to ensure the loop continues for all containers

--- a/lxc-updater.sh
+++ b/lxc-updater.sh
@@ -24,7 +24,7 @@
 
 set -Eeuo pipefail
 
-SCRIPT_VERSION="v0.10.8"
+SCRIPT_VERSION="v0.10.9"
 
 # --- LOGGING ---
 LOG_STDOUT="${LOG_STDOUT:-yes}" # Set to "no" to disable console output (useful for cron)
@@ -678,6 +678,7 @@ main() {
   log DEBUG "Detected ${#lxc_list[@]} running containers: ${lxc_list[*]:-none}"
 
   if [[ ${#lxc_list[@]} -eq 0 ]]; then
+    log INFO "⏭️ No running containers found."
     report+="• ⏭️ No running containers found."$'\n'
   else
     # Disable immediate exit to ensure the loop continues for all containers

--- a/pve-update-notifier.sh
+++ b/pve-update-notifier.sh
@@ -14,7 +14,7 @@
 # Use this script at your own risk. The authors are not responsible for any
 # data loss, system instability, or service downtime caused by running it.
 
-SCRIPT_VERSION="v0.10.8"
+SCRIPT_VERSION="v0.10.9"
 
 # Add this path variable so Cron can find the required system commands
 export PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
@@ -432,6 +432,7 @@ if $IS_PVE_HOST; then
   mapfile -t lxc_list < <(pct list | awk 'NR>1 && $2=="running" {print $1 ":" $NF}')
 
   if [ ${#lxc_list[@]} -eq 0 ]; then
+      log INFO "⏭️ No running containers found."
       REPORT+="• ⏭️ No running containers found"$'\n'
   else
       # ⚡ Bolt: Use a temporary directory to store bounded concurrent execution results

--- a/system-update-notifier.sh
+++ b/system-update-notifier.sh
@@ -2,7 +2,7 @@
 # System Update Notifier
 # Updates the host system via apt and sends a Telegram notification.
 
-SCRIPT_VERSION="v0.10.8"
+SCRIPT_VERSION="v0.10.9"
 
 export PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 


### PR DESCRIPTION
💡 What: Added `log INFO "⏭️ No running containers found."` to `lxc-updater.sh`, `lxc-cleanup.sh`, and `pve-update-notifier.sh`. Also bumped `SCRIPT_VERSION` in all 4 scripts from `v0.10.8` to `v0.10.9`.
🎯 Why: Previously, when no running containers were found, the scripts would silently append the empty state message to the generated report but would not output anything visibly to the CLI, leaving the user without immediate feedback.
♿ Accessibility: Improves CLI scannability and provides immediate visual feedback for the user instead of a silent/hanging interface.

---
*PR created automatically by Jules for task [18213967797286220145](https://jules.google.com/task/18213967797286220145) started by @spupuz*