### PR TITLE
🎨 Palette: Fix interleaved garbled output in concurrent loops

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,7 @@
+## 2024-05-18 - Missing CLI empty state logging
+**Learning:** Found that when looping through updates or operations, empty states were not logged to the local CLI visibly, but only added to remote payloads.
+**Action:** Always provide explicit CLI logging (e.g., `log INFO "⏭️ No running containers found."`) for empty states and don't solely append empty state messages to remote payload variables.
+
+## 2024-05-18 - Concurrent UX Mirroring Garbled Output
+**Learning:** Found that using the `>&3` log mirroring pattern directly inside a concurrently executing background subshell bypasses file-based buffering, causing output to interleave and become garbled on the terminal.
+**Action:** When printing background logs synchronously to the screen, always buffer them into a temporary file first, and only execute the `log ... >&3` logic sequentially in the main process loop after jobs complete, ensuring terminal outputs do not overlap.

--- a/lxc-cleanup.sh
+++ b/lxc-cleanup.sh
@@ -30,7 +30,7 @@
 
 set -Eeuo pipefail
 
-SCRIPT_VERSION="v0.11.0"
+SCRIPT_VERSION="v0.11.1"
 
 # --- LOGGING ---
 LOG_STDOUT="${LOG_STDOUT:-yes}" # Set to "no" to disable console output (useful for cron)
@@ -680,17 +680,6 @@ main() {
         section_banner "$ctid" "$ctraw"
         local result
         result=$(cleanup_lxc "$ctid" "$ctname" "$ctraw")
-        # Mirror container outcome immediately (bypass subshell stdout capture)
-        local first_line="${result%%$'\n'*}"
-        if [[ "$first_line" == *"✅"* ]]; then
-          log INFO "${first_line#* ($ctname): }" >&3
-        elif [[ "$first_line" == *"⚠️"* ]]; then
-          log WARN "${first_line#* ($ctname): }" >&3
-        elif [[ "$first_line" == *"❌"* ]]; then
-          log ERROR "${first_line#* ($ctname): }" >&3
-        else
-          log INFO "${first_line#* ($ctname): }" >&3
-        fi
         echo "$result" > "$tmp_dir/$ctid"
         section_footer "$ctid" "$ctraw"
       ) >"$tmp_dir/$ctid.log" 2>&1 &
@@ -708,7 +697,6 @@ main() {
     # ⚡ Bolt: Print each container's complete output as one block when it
     # finishes. A job only counts as done once it has been reaped by wait -n,
     # which also guarantees its buffer file is fully flushed and complete.
-    exec 3>&-
     local printed=0
     while (( printed < pending )); do
       wait -n || true
@@ -720,11 +708,30 @@ main() {
         [[ -n "$pid" ]] || continue
         if ! kill -0 "$pid" 2>/dev/null; then
           cat "$tmp_dir/$ctid.log" >&2
+
+          local ctname="${item##*:}"
+
+          if [[ -f "$tmp_dir/$ctid" ]]; then
+            local result
+            result=$(<"$tmp_dir/$ctid")
+            local first_line="${result%%$'\n'*}"
+            if [[ "$first_line" == *"✅"* ]]; then
+              log INFO "${first_line#* ($ctname): }" >&3
+            elif [[ "$first_line" == *"⚠️"* ]]; then
+              log WARN "${first_line#* ($ctname): }" >&3
+            elif [[ "$first_line" == *"❌"* ]]; then
+              log ERROR "${first_line#* ($ctname): }" >&3
+            else
+              log INFO "${first_line#* ($ctname): }" >&3
+            fi
+          fi
+
           : > "$tmp_dir/$ctid.printed"
           ((printed++))
         fi
       done
     done
+    exec 3>&-
 
     # Read the results in the original order
     for item in "${lxc_list[@]}"; do

--- a/lxc-updater.sh
+++ b/lxc-updater.sh
@@ -24,7 +24,7 @@
 
 set -Eeuo pipefail
 
-SCRIPT_VERSION="v0.11.0"
+SCRIPT_VERSION="v0.11.1"
 
 # --- LOGGING ---
 LOG_STDOUT="${LOG_STDOUT:-yes}" # Set to "no" to disable console output (useful for cron)
@@ -725,17 +725,6 @@ main() {
         section_banner "$ctid" "$ctraw"
         local result
         result=$(update_lxc "$ctid" "$ctname" "$ctraw")
-        # Mirror container outcome immediately (bypass subshell stdout capture)
-        local first_line="${result%%$'\n'*}"
-        if [[ "$first_line" == *"✅"* ]]; then
-          log INFO "${first_line#* ($ctname): }" >&3
-        elif [[ "$first_line" == *"⚠️"* ]]; then
-          log WARN "${first_line#* ($ctname): }" >&3
-        elif [[ "$first_line" == *"❌"* ]]; then
-          log ERROR "${first_line#* ($ctname): }" >&3
-        else
-          log INFO "${first_line#* ($ctname): }" >&3
-        fi
         echo "$result" > "$tmp_dir/$ctid"
         section_footer "$ctid" "$ctraw"
       ) >"$tmp_dir/$ctid.log" 2>&1 &
@@ -753,7 +742,6 @@ main() {
     # ⚡ Bolt: Print each container's complete output as one block when it
     # finishes. A job only counts as done once it has been reaped by wait -n,
     # which also guarantees its buffer file is fully flushed and complete.
-    exec 3>&-
     local printed=0
     while (( printed < pending )); do
       wait -n || true
@@ -765,11 +753,30 @@ main() {
         [[ -n "$pid" ]] || continue
         if ! kill -0 "$pid" 2>/dev/null; then
           cat "$tmp_dir/$ctid.log" >&2
+
+          local ctname="${item##*:}"
+
+          if [[ -f "$tmp_dir/$ctid" ]]; then
+            local result
+            result=$(<"$tmp_dir/$ctid")
+            local first_line="${result%%$'\n'*}"
+            if [[ "$first_line" == *"✅"* ]]; then
+              log INFO "${first_line#* ($ctname): }" >&3
+            elif [[ "$first_line" == *"⚠️"* ]]; then
+              log WARN "${first_line#* ($ctname): }" >&3
+            elif [[ "$first_line" == *"❌"* ]]; then
+              log ERROR "${first_line#* ($ctname): }" >&3
+            else
+              log INFO "${first_line#* ($ctname): }" >&3
+            fi
+          fi
+
           : > "$tmp_dir/$ctid.printed"
           ((printed++))
         fi
       done
     done
+    exec 3>&-
 
     # Read the results in the original order
     for item in "${lxc_list[@]}"; do

--- a/pve-update-notifier.sh
+++ b/pve-update-notifier.sh
@@ -14,7 +14,7 @@
 # Use this script at your own risk. The authors are not responsible for any
 # data loss, system instability, or service downtime caused by running it.
 
-SCRIPT_VERSION="v0.11.0"
+SCRIPT_VERSION="v0.11.1"
 
 # Add this path variable so Cron can find the required system commands
 export PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"

--- a/system-update-notifier.sh
+++ b/system-update-notifier.sh
@@ -2,7 +2,7 @@
 # System Update Notifier
 # Updates the host system via apt and sends a Telegram notification.
 
-SCRIPT_VERSION="v0.11.0"
+SCRIPT_VERSION="v0.11.1"
 
 export PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 


### PR DESCRIPTION
Moved the explicit `log INFO ... >&3` logic out of the concurrently running subshells into the sequential monitoring loop to prevent interleaved, garbled output on the terminal.

---
*PR created automatically by Jules for task [5426501846823836170](https://jules.google.com/task/5426501846823836170) started by @spupuz*