### PR TITLE
🛡️ Sentinel: [CRITICAL] Prevent Gotify token leakage in pve-update-notifier.sh

### DIFF
--- a/pve-update-notifier.sh
+++ b/pve-update-notifier.sh
@@ -167,7 +167,7 @@ send_gotify() {
     local message="$1"
     [[ -z "${GOTIFY_SERVER}" || -z "${GOTIFY_TOKEN}" ]] && { log INFO "⏭️ Gotify config missing, skipping notification. Please set GOTIFY_SERVER and GOTIFY_TOKEN in gotify.conf or /etc/pve-gotify.conf"; return 0; }
 
-    local url="${GOTIFY_SERVER}/message?token=${GOTIFY_TOKEN}"
+    local url="${GOTIFY_SERVER}/message"
 
     # Enforce HTTPS when the server URL uses https://; allow plain HTTP otherwise (local LAN)
     local curl_flags=(-s --connect-timeout 10 --max-time 30)
@@ -175,11 +175,16 @@ send_gotify() {
         curl_flags+=(--proto '=https' --tlsv1.2)
     fi
 
-    RESPONSE=$(curl "${curl_flags[@]}" \
-        -X POST "$url" \
-        -F "title=Proxmox Update Report" \
-        -F "message=${message}" \
-        -F "priority=5")
+    # 🛡️ Sentinel Security Fix: Prevent TOKEN leakage and fix ARG_MAX for large reports.
+    # Pass token securely via header instead of URL to avoid proxy/webserver logging.
+    # Use process substitution for config and pass the message body via stdin.
+    RESPONSE=$(curl "${curl_flags[@]}" -X POST -K <(cat <<CURL_CONF
+url = "$url"
+header = "X-Gotify-Key: $GOTIFY_TOKEN"
+form = "title=Proxmox Update Report"
+form = "priority=5"
+CURL_CONF
+) --form "message=<-" <<< "$message")
 
     if [[ $RESPONSE == *'"id"'* ]]; then
         log INFO "✅ Gotify delivery successful."


### PR DESCRIPTION
🛡️ Sentinel: [CRITICAL] Fix Gotify API token information disclosure

🚨 **Severity:** CRITICAL
💡 **Vulnerability:** The `pve-update-notifier.sh` script previously passed the `GOTIFY_TOKEN` as a URL query parameter (`?token=secret`) and the message payload as a command-line argument to `curl`. This exposes the token to proxy/webserver access logs and both the token and the message content to local users via the process table (`ps aux` / `/proc/.../cmdline`).
🎯 **Impact:** Local system users or intermediate network proxies could intercept the Gotify token, potentially spoofing notifications or gaining unauthorized access to the notification system. Passing large payloads as arguments can also cause `ARG_MAX` length errors.
🔧 **Fix:** 
- Moved the token from the URL query string to an HTTP header (`X-Gotify-Key`).
- Refactored the `curl` command to read configuration securely using `curl -K` and process substitution, hiding the arguments from the process list.
- Read the message payload from standard input via `--form "message=<-"` to prevent exposure and bypass `ARG_MAX` limits.
✅ **Verification:** Verified that the script syntax remains correct, mock payload structures were tested to parse correctly, and test suites run successfully. Added relevant entry to Sentinel journal.

---
*PR created automatically by Jules for task [11460632242521905109](https://jules.google.com/task/11460632242521905109) started by @spupuz*