### PR TITLE
🛡️ Sentinel: [HIGH] Fix token leakage in Gotify payload

### DIFF
--- a/pve-update-notifier.sh
+++ b/pve-update-notifier.sh
@@ -167,7 +167,7 @@ send_gotify() {
     local message="$1"
     [[ -z "${GOTIFY_SERVER}" || -z "${GOTIFY_TOKEN}" ]] && { log INFO "⏭️ Gotify config missing, skipping notification. Please set GOTIFY_SERVER and GOTIFY_TOKEN in gotify.conf or /etc/pve-gotify.conf"; return 0; }
 
-    local url="${GOTIFY_SERVER}/message?token=${GOTIFY_TOKEN}"
+    local url="${GOTIFY_SERVER}/message"
 
     # Enforce HTTPS when the server URL uses https://; allow plain HTTP otherwise (local LAN)
     local curl_flags=(-s --connect-timeout 10 --max-time 30)
@@ -175,11 +175,15 @@ send_gotify() {
         curl_flags+=(--proto '=https' --tlsv1.2)
     fi
 
-    RESPONSE=$(curl "${curl_flags[@]}" \
-        -X POST "$url" \
-        -F "title=Proxmox Update Report" \
-        -F "message=${message}" \
-        -F "priority=5")
+    # 🛡️ Sentinel Security Fix: Prevent TOKEN leakage and fix ARG_MAX for large reports.
+    # Use process substitution for config and pass the message body via stdin.
+    RESPONSE=$(curl "${curl_flags[@]}" -X POST -K <(cat <<CURL_CONF
+url = "$url"
+header = "X-Gotify-Key: $GOTIFY_TOKEN"
+form = "title=Proxmox Update Report"
+form = "priority=5"
+CURL_CONF
+) --form "message=<-" <<< "$message")
 
     if [[ $RESPONSE == *'"id"'* ]]; then
         log INFO "✅ Gotify delivery successful."


### PR DESCRIPTION
🛡️ Sentinel: [HIGH] Fix token leakage in Gotify payload

🚨 Severity: HIGH
💡 Vulnerability: The Gotify API token was being passed as a URL parameter (`?token=...`) and the entire notification message was passed as a command-line argument. This meant the token and full payload were visible in system process lists (`ps aux`) and potentially logged in proxy/access logs.
🎯 Impact: Local system users could intercept the API token to impersonate the notification bot, and large payloads could exceed the shell's `ARG_MAX` limit, causing the notification to fail silently.
🔧 Fix: Refactored the `send_gotify` function in `pve-update-notifier.sh` to pass the token securely using the `X-Gotify-Key` HTTP header. Also utilized process substitution (`-K <(cat <<CURL_CONF...)`) to feed options to `curl` securely, and sent the large message body via standard input using a here-string (`--form "message=<-" <<< "$message"`).
✅ Verification: Tested syntax with `bash -n`, passed existing UX mirror tests, and manually verified the exact curl syntax prevents leaking into process arguments.

---
*PR created automatically by Jules for task [13386882358836172850](https://jules.google.com/task/13386882358836172850) started by @spupuz*