### PR TITLE
🎨 Palette: Add symmetrical CLI logging for final execution summaries

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-08-30 - Symmetrical CLI and Remote UX States
+**Learning:** When generating remote payloads (like Telegram summaries) that aggregate parallel or background work into final `✅`/`❌`/`⏭️` states, failing to mirror those same conclusive states to the local CLI leaves the user with an asymmetrical, silent resolution.
+**Action:** Always ensure that critical summary lines added to a remote payload variable (`report+=...`) are symmetrically mirrored to the local standard output/error (via `log INFO ...`) so both the remote and local consumer receive clear, final feedback.

--- a/lxc-cleanup.sh
+++ b/lxc-cleanup.sh
@@ -30,7 +30,7 @@
 
 set -Eeuo pipefail
 
-SCRIPT_VERSION="v0.11.1"
+SCRIPT_VERSION="v0.11.2"
 
 # --- LOGGING ---
 LOG_STDOUT="${LOG_STDOUT:-yes}" # Set to "no" to disable console output (useful for cron)
@@ -758,6 +758,10 @@ main() {
   report+="✅ Cleaned: ${clean_count}"$'\n'
   report+="⏭️ Excluded: ${skip_count}"$'\n'
   report+="❌ Failed: ${fail_count}"$'\n'
+
+  log INFO "✅ Cleaned: ${clean_count}"
+  log INFO "⏭️ Excluded: ${skip_count}"
+  log INFO "❌ Failed: ${fail_count}"
 
   send_telegram "$report"
 }

--- a/lxc-updater.sh
+++ b/lxc-updater.sh
@@ -24,7 +24,7 @@
 
 set -Eeuo pipefail
 
-SCRIPT_VERSION="v0.11.1"
+SCRIPT_VERSION="v0.11.2"
 
 # --- LOGGING ---
 LOG_STDOUT="${LOG_STDOUT:-yes}" # Set to "no" to disable console output (useful for cron)
@@ -804,6 +804,10 @@ main() {
   report+="✅ Updated: ${ok_count}"$'\n'
   report+="⏭️ Excluded: ${skip_count}"$'\n'
   report+="❌ Failed: ${fail_count}"$'\n'
+
+  log INFO "✅ Updated: ${ok_count}"
+  log INFO "⏭️ Excluded: ${skip_count}"
+  log INFO "❌ Failed: ${fail_count}"
 
   send_telegram "$report"
 }

--- a/pve-update-notifier.sh
+++ b/pve-update-notifier.sh
@@ -14,7 +14,7 @@
 # Use this script at your own risk. The authors are not responsible for any
 # data loss, system instability, or service downtime caused by running it.
 
-SCRIPT_VERSION="v0.11.1"
+SCRIPT_VERSION="v0.11.2"
 
 # Add this path variable so Cron can find the required system commands
 export PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"

--- a/system-update-notifier.sh
+++ b/system-update-notifier.sh
@@ -2,7 +2,7 @@
 # System Update Notifier
 # Updates the host system via apt and sends a Telegram notification.
 
-SCRIPT_VERSION="v0.11.1"
+SCRIPT_VERSION="v0.11.2"
 
 export PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 
@@ -334,6 +334,12 @@ else
   REBOOT_NOTE="✅ No kernel update"
 fi
 REPORT+=$'\n'"$REBOOT_NOTE"
+
+if [[ "$REBOOT_NOTE" == *"⚠️"* ]]; then
+  log WARN "${REBOOT_NOTE}"
+else
+  log INFO "${REBOOT_NOTE}"
+fi
 
 log INFO "✅ Upgrade completed"
 log INFO "ℹ️ Sending Telegram notification..."


### PR DESCRIPTION
💡 What: Added symmetrical CLI log mirroring for final execution summaries in `lxc-updater.sh`, `lxc-cleanup.sh`, and `system-update-notifier.sh`.
🎯 Why: Previously, the final summary metrics (total updated, failed, excluded, or reboot required) were only appended to the remote Telegram payload string. This left local CLI users with a sudden silent exit and an asymmetrical feedback experience, making it harder to quickly scan the overall script outcome from the console or syslog.
📸 Before/After: 
Before: Script finishes executing tasks and silently exits.
After: 
`[INFO] ✅ Updated: 5`
`[INFO] ⏭️ Excluded: 1`
`[INFO] ❌ Failed: 0`
♿ Accessibility: Improves visual and textual scannability for local shell consumers, providing immediate, conclusive feedback without requiring them to parse the entire remote string or check an external platform.

---
*PR created automatically by Jules for task [18344832269854030397](https://jules.google.com/task/18344832269854030397) started by @spupuz*