### PR TITLE
🛡️ Sentinel: [HIGH] Fix DoS in app updater by allowing spaces in commands

### DIFF
--- a/lxc-updater.sh
+++ b/lxc-updater.sh
@@ -498,7 +498,7 @@ EOF
   # 1. ATTEMPT APP UPDATE (Custom/Helper Scripts)
   if [[ -n "$app_cmd" ]]; then
     # 🛡️ Sentinel Security Fix: Sanitize app_cmd to prevent arbitrary command injection from a compromised container
-    local safe_app_cmd="${app_cmd//[^a-zA-Z0-9_\-\.\/]/}"
+    local safe_app_cmd="${app_cmd//[^a-zA-Z0-9_\-\.\/ ]/}"
     if [[ "$app_cmd" != "$safe_app_cmd" ]]; then
       log ERROR "❌ SECURITY CRITICAL: $app_cmd contains invalid characters. Refusing to execute to prevent command injection."
       return 1

--- a/scripts/test_app_cmd_sanitize.sh
+++ b/scripts/test_app_cmd_sanitize.sh
@@ -2,7 +2,7 @@
 # Test the sanitization regex logic used in the script
 test_sanitize() {
   local app_cmd="$1"
-  local safe_app_cmd="${app_cmd//[^a-zA-Z0-9_\-\.\/]/}"
+  local safe_app_cmd="${app_cmd//[^a-zA-Z0-9_\-\.\/ ]/}"
   if [[ "$app_cmd" != "$safe_app_cmd" ]]; then
     echo "REJECTED: $app_cmd"
   else
@@ -38,6 +38,18 @@ fi
 out5=$(test_sanitize "/bin/update\`whoami\`")
 if [[ "$out5" != "REJECTED: /bin/update\`whoami\`" ]]; then
   echo "❌ Test 5 failed! Got $out5"
+  fail=1
+fi
+
+out6=$(test_sanitize "pihole -up")
+if [[ "$out6" != "ACCEPTED: pihole -up" ]]; then
+  echo "❌ Test 6 failed! Got $out6"
+  fail=1
+fi
+
+out7=$(test_sanitize "ha core update")
+if [[ "$out7" != "ACCEPTED: ha core update" ]]; then
+  echo "❌ Test 7 failed! Got $out7"
   fail=1
 fi
 


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** A previous security fix used an overly aggressive regex (`[^a-zA-Z0-9_\-\.\/]`) to sanitize the `app_cmd` variable to prevent command injection. Because it stripped spaces, it caused a Denial of Service (DoS) for valid multi-word commands (like `pihole -up` or `ha core update`), causing the core application update functionality to fail.
🎯 **Impact:** Prevents legitimate users from updating applications that require command line arguments.
🔧 **Fix:** Adjusted the allowlist regex in `lxc-updater.sh` and the corresponding unit test to include a space (`[^a-zA-Z0-9_\-\.\/ ]`). This restores functionality while continuing to block dangerous shell metacharacters (e.g., `&`, `|`, `;`, `$`, backticks) that lead to command injection.
✅ **Verification:** Unit tests in `./scripts/test_app_cmd_sanitize.sh` were updated and confirmed to pass for commands with spaces, while continuing to reject malicious injection attempts.

---
*PR created automatically by Jules for task [3515727048694156709](https://jules.google.com/task/3515727048694156709) started by @spupuz*