### PR TITLE
🎨 Palette: Align error log levels with emoji prefixes

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-09-02 - Ensure Empty State Feedback in CLI output
+**Learning:** The CLI execution output is left silently hanging when no updates or states are matched for a final operation.
+**Action:** Add explicit CLI logging for empty states before sending remote payload notifications.

--- a/lxc-cleanup.sh
+++ b/lxc-cleanup.sh
@@ -761,7 +761,11 @@ main() {
 
   log INFO "✅ Cleaned: ${clean_count}"
   log INFO "⏭️ Excluded: ${skip_count}"
-  log INFO "❌ Failed: ${fail_count}"
+  if [[ "${fail_count}" -gt 0 ]]; then
+    log ERROR "❌ Failed: ${fail_count}"
+  else
+    log INFO "❌ Failed: ${fail_count}"
+  fi
 
   send_telegram "$report"
 }

--- a/lxc-updater.sh
+++ b/lxc-updater.sh
@@ -807,7 +807,11 @@ main() {
 
   log INFO "✅ Updated: ${ok_count}"
   log INFO "⏭️ Excluded: ${skip_count}"
-  log INFO "❌ Failed: ${fail_count}"
+  if [[ "${fail_count}" -gt 0 ]]; then
+    log ERROR "❌ Failed: ${fail_count}"
+  else
+    log INFO "❌ Failed: ${fail_count}"
+  fi
 
   send_telegram "$report"
 }


### PR DESCRIPTION
💡 **What**: Changed `log INFO` to conditionally use `log ERROR` for "❌ Failed:" summary logs when `fail_count > 0` in `lxc-updater.sh` and `lxc-cleanup.sh`.

🎯 **Why**: To ensure log levels align strictly with their semantic emoji prefixes and accurately convey the script's final execution state to the CLI user, while preventing false-positive ERROR logs during successful runs.

📸 **Before/After**:
Before:
`[INFO] ❌ Failed: 3`

After:
`[ERROR] ❌ Failed: 3`

♿ **Accessibility**: Improves semantic meaning and scanability of the terminal output for automated systems and human readers.

---
*PR created automatically by Jules for task [17671437778330728615](https://jules.google.com/task/17671437778330728615) started by @spupuz*