### PR TITLE
🛡️ Sentinel: [HIGH] Fix arbitrary file deletion via symlink attack in user cache cleanup

### DIFF
--- a/lxc-cleanup.sh
+++ b/lxc-cleanup.sh
@@ -490,8 +490,10 @@ if [ "${safe_clean_docker_tmp}" = "yes" ] && command -v docker >/dev/null 2>&1; 
 fi
 
 # 5. USER CACHES (~/.cache, npm, pnpm, go)
+# 🛡️ Sentinel Security Fix: Prevent arbitrary file deletion via symlink attack in user cache cleanup
+# Check if cache directories are actual directories and not symlinks before recursively removing their contents
 if [ "${safe_clean_user_cache}" = "yes" ]; then
-  step USER_CACHE 'for home in /root /home/*; do [ -d "\$home" ] || continue; rm -rf "\$home"/.cache/* >/dev/null 2>&1 || true; rm -rf "\$home"/.npm/_cacache >/dev/null 2>&1 || true; rm -rf "\$home"/.local/share/pnpm/store >/dev/null 2>&1 || true; rm -rf "\$home"/go/pkg/mod/cache >/dev/null 2>&1 || true; done'
+  step USER_CACHE 'for home in /root /home/*; do [ -d "\$home" ] || continue; for dir in "\$home"/.cache "\$home"/.npm/_cacache "\$home"/.local/share/pnpm/store "\$home"/go/pkg/mod/cache; do [ -d "\$dir" ] && [ ! -L "\$dir" ] && rm -rf "\$dir"/* >/dev/null 2>&1 || true; done; done'
 fi
 
 # 6. OLD /tmp FILES (older than 7 days)


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** The script blindly executed `rm -rf "$home"/.cache/*` and other cache directories inside LXC containers. If a low-privileged user within the container replaced their `~/.cache` directory with a symlink pointing to sensitive system directories (e.g., `/etc` or `/`), the script (running as root) would follow the symlink and delete the target's contents.
🎯 **Impact:** Local Privilege Escalation / Arbitrary File Deletion. A low-privileged user inside the container could cause catastrophic data loss or container destruction.
🔧 **Fix:** Added strict verification to ensure target user cache directories are actual directories and NOT symlinks (`[ -d "$dir" ] && [ ! -L "$dir" ]`) before executing the `rm -rf` command.
✅ **Verification:** Verified that symlinked cache directories are skipped safely and normal cache directories are cleaned correctly.

---
*PR created automatically by Jules for task [7722113520583539564](https://jules.google.com/task/7722113520583539564) started by @spupuz*