### PR TITLE
🎨 Palette: Fix log level semantic emojis

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-10-24 - Aligning log levels with semantic emojis
+**Learning:** Mismatched emojis in CLI log outputs (e.g., using a failure emoji with an INFO level) can cause visual confusion and disrupt CLI scannability.
+**Action:** Always ensure log levels align strictly with their semantic emoji prefixes (e.g., use `✅` for `INFO` when reporting zero failures).

--- a/lxc-cleanup.sh
+++ b/lxc-cleanup.sh
@@ -767,7 +767,7 @@ main() {
   if [[ "${fail_count}" -gt 0 ]]; then
     log ERROR "❌ Failed: ${fail_count}"
   else
-    log INFO "❌ Failed: ${fail_count}"
+    log INFO "✅ Failed: ${fail_count}"
   fi
 
   send_telegram "$report"

--- a/lxc-updater.sh
+++ b/lxc-updater.sh
@@ -811,7 +811,7 @@ main() {
   if [[ "${fail_count}" -gt 0 ]]; then
     log ERROR "❌ Failed: ${fail_count}"
   else
-    log INFO "❌ Failed: ${fail_count}"
+    log INFO "✅ Failed: ${fail_count}"
   fi
 
   send_telegram "$report"


### PR DESCRIPTION
💡 What: Updated the `fail_count` log line in `lxc-cleanup.sh` and `lxc-updater.sh` to use the `✅` emoji instead of `❌` when the failure count is 0.

🎯 Why: Mismatched emojis in CLI log outputs (e.g., using a failure emoji with an INFO level) can cause visual confusion and disrupt CLI scannability for users.

📸 Before/After:
Before:
`log INFO "❌ Failed: 0"`

After:
`log INFO "✅ Failed: 0"`

♿ Accessibility: Improves visual scanning of CLI outputs and reduces cognitive load by ensuring icons match their context.

---
*PR created automatically by Jules for task [1095536590844955390](https://jules.google.com/task/1095536590844955390) started by @spupuz*