### PR TITLE
🎨 Palette: [UX improvement] Fix false-positive error emoji on zero failures

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2026-09-02 - [Summary State Emojis]
+**Learning:** When displaying failure counts in a summary that is 0, keeping the ❌ emoji creates cognitive dissonance and looks like an error state despite an INFO log level.
+**Action:** Always swap failure emojis to success/neutral indicators (e.g., ✅) when the count is zero to visually reinforce a successful run.

--- a/lxc-cleanup.sh
+++ b/lxc-cleanup.sh
@@ -30,7 +30,7 @@
 
 set -Eeuo pipefail
 
-SCRIPT_VERSION="v0.11.3"
+SCRIPT_VERSION="v0.11.4"
 
 # --- LOGGING ---
 LOG_STDOUT="${LOG_STDOUT:-yes}" # Set to "no" to disable console output (useful for cron)
@@ -767,7 +767,7 @@ main() {
   if [[ "${fail_count}" -gt 0 ]]; then
     log ERROR "❌ Failed: ${fail_count}"
   else
-    log INFO "❌ Failed: ${fail_count}"
+    log INFO "✅ Failed: ${fail_count}"
   fi
 
   send_telegram "$report"

--- a/lxc-updater.sh
+++ b/lxc-updater.sh
@@ -24,7 +24,7 @@
 
 set -Eeuo pipefail
 
-SCRIPT_VERSION="v0.11.3"
+SCRIPT_VERSION="v0.11.4"
 
 # --- LOGGING ---
 LOG_STDOUT="${LOG_STDOUT:-yes}" # Set to "no" to disable console output (useful for cron)
@@ -811,7 +811,7 @@ main() {
   if [[ "${fail_count}" -gt 0 ]]; then
     log ERROR "❌ Failed: ${fail_count}"
   else
-    log INFO "❌ Failed: ${fail_count}"
+    log INFO "✅ Failed: ${fail_count}"
   fi
 
   send_telegram "$report"

--- a/pve-update-notifier.sh
+++ b/pve-update-notifier.sh
@@ -14,7 +14,7 @@
 # Use this script at your own risk. The authors are not responsible for any
 # data loss, system instability, or service downtime caused by running it.
 
-SCRIPT_VERSION="v0.11.3"
+SCRIPT_VERSION="v0.11.4"
 
 # Add this path variable so Cron can find the required system commands
 export PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"

--- a/system-update-notifier.sh
+++ b/system-update-notifier.sh
@@ -2,7 +2,7 @@
 # System Update Notifier
 # Updates the host system via apt and sends a Telegram notification.
 
-SCRIPT_VERSION="v0.11.3"
+SCRIPT_VERSION="v0.11.4"
 
 export PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 


### PR DESCRIPTION
💡 **What:** Changed the CLI logger to use a success (`✅`) emoji instead of an error (`❌`) emoji when outputting the final failure count and that count is zero. Bumped script versions.
🎯 **Why:** When users observe a zero failure count in the summary output, seeing a red "X" creates cognitive dissonance and makes it look like an error state, despite being accompanied by an INFO level log. This clarifies the success state.
📸 **Before/After:**
Before: `INFO [lxc-cleanup] ❌ Failed: 0`
After:  `INFO [lxc-cleanup] ✅ Failed: 0`
♿ **Accessibility:** Improves scannability and prevents confusion for visually parsing logs quickly.

---
*PR created automatically by Jules for task [3186687342050777265](https://jules.google.com/task/3186687342050777265) started by @spupuz*