### PR TITLE
🛡️ Sentinel: [HIGH] Fix auto-update bypass via insecure argument check

### DIFF
--- a/lxc-cleanup.sh
+++ b/lxc-cleanup.sh
@@ -286,7 +286,7 @@ auto_update() {
 
   log WARN "⚠️ New version available: $latest_tag (current: $SCRIPT_VERSION)"
 
-  if [[ "$force" == "no" && "$auto_update_enabled" == "no" ]]; then
+  if [[ "$force" != "yes" && "$auto_update_enabled" != "yes" ]]; then
     log INFO "ℹ️ Auto-update is disabled. Sending update available notification..."
     send_telegram "⚠️ *Script Update Available*
 

--- a/lxc-updater.sh
+++ b/lxc-updater.sh
@@ -307,7 +307,7 @@ auto_update() {
 
   log WARN "⚠️ New version available: $latest_tag (current: $SCRIPT_VERSION)"
 
-  if [[ "$force" == "no" && "$auto_update_enabled" == "no" ]]; then
+  if [[ "$force" != "yes" && "$auto_update_enabled" != "yes" ]]; then
     log INFO "ℹ️ Auto-update is disabled. Sending update available notification..."
     send_telegram "⚠️ *Script Update Available*
 

--- a/pve-update-notifier.sh
+++ b/pve-update-notifier.sh
@@ -275,7 +275,7 @@ auto_update() {
 
   log WARN "⚠️ New version available: $latest_tag (current: $SCRIPT_VERSION)"
 
-  if [[ "$force" == "no" && "$auto_update_enabled" == "no" ]]; then
+  if [[ "$force" != "yes" && "$auto_update_enabled" != "yes" ]]; then
     log INFO "ℹ️ Auto-update is disabled. Sending update available notification..."
     send_notification "⚠️ *Script Update Available*
 

--- a/system-update-notifier.sh
+++ b/system-update-notifier.sh
@@ -181,7 +181,7 @@ auto_update() {
 
   log WARN "⚠️ New version available: $latest_tag (current: $SCRIPT_VERSION)"
 
-  if [[ "$force" == "no" && "$auto_update_enabled" == "no" ]]; then
+  if [[ "$force" != "yes" && "$auto_update_enabled" != "yes" ]]; then
     log INFO "ℹ️ Auto-update is disabled. Sending update available notification..."
     send_telegram "⚠️ *Script Update Available*
 


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** The auto-update check used an 'allow-by-default' negative comparison `if [[ "$force" == "no" && "$auto_update_enabled" == "no" ]]`. Passing any unexpected argument like `--foo` to the script caused the condition to evaluate to false, bypassing the protection and unintentionally enabling auto-update.
🎯 **Impact:** If an administrator or script runner accidentally provided an unexpected argument or flag, the script would unexpectedly initiate the auto-update process without explicit consent, ignoring the `AUTO_UPDATE="no"` configuration.
🔧 **Fix:** Changed the boolean-like flag checks in `lxc-cleanup.sh`, `lxc-updater.sh`, `pve-update-notifier.sh`, and `system-update-notifier.sh` to use secure, 'deny-by-default' positive comparisons (`!= "yes"`). 
✅ **Verification:**
1. Ensured the logic changes are correct across all four scripts.
2. Verified that running tests locally (`./scripts/test_app_cmd_sanitize.sh` and `./scripts/test_ux_mirrors.sh`) succeed.
3. Created the `.jules/sentinel.md` entry as required.

---
*PR created automatically by Jules for task [3269200497756151084](https://jules.google.com/task/3269200497756151084) started by @spupuz*