### PR TITLE
🎨 Palette: Conditionally align failure emojis in payloads

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-24 - Avoid false-positive failure emojis in remote payloads
+**Learning:** Hardcoding error emojis (like `❌`) in notification payloads for zero-count metrics causes unnecessary user alarm.
+**Action:** Always conditionally align the payload emoji to match the local CLI log level and the true metric state (e.g., `✅ Failed: 0`).

--- a/lxc-cleanup.sh
+++ b/lxc-cleanup.sh
@@ -30,7 +30,7 @@
 
 set -Eeuo pipefail
 
-SCRIPT_VERSION="v0.11.5"
+SCRIPT_VERSION="v0.11.6"
 
 # --- LOGGING ---
 LOG_STDOUT="${LOG_STDOUT:-yes}" # Set to "no" to disable console output (useful for cron)
@@ -762,7 +762,11 @@ main() {
   report+=$'\n'
   report+="✅ Cleaned: ${clean_count}"$'\n'
   report+="⏭️ Excluded: ${skip_count}"$'\n'
-  report+="❌ Failed: ${fail_count}"$'\n'
+  if [[ "${fail_count}" -gt 0 ]]; then
+    report+="❌ Failed: ${fail_count}"$'\n'
+  else
+    report+="✅ Failed: ${fail_count}"$'\n'
+  fi
 
   log INFO "✅ Cleaned: ${clean_count}"
   log INFO "⏭️ Excluded: ${skip_count}"

--- a/lxc-updater.sh
+++ b/lxc-updater.sh
@@ -24,7 +24,7 @@
 
 set -Eeuo pipefail
 
-SCRIPT_VERSION="v0.11.5"
+SCRIPT_VERSION="v0.11.6"
 
 # --- LOGGING ---
 LOG_STDOUT="${LOG_STDOUT:-yes}" # Set to "no" to disable console output (useful for cron)
@@ -806,7 +806,11 @@ main() {
   report+=$'\n'
   report+="✅ Updated: ${ok_count}"$'\n'
   report+="⏭️ Excluded: ${skip_count}"$'\n'
-  report+="❌ Failed: ${fail_count}"$'\n'
+  if [[ "${fail_count}" -gt 0 ]]; then
+    report+="❌ Failed: ${fail_count}"$'\n'
+  else
+    report+="✅ Failed: ${fail_count}"$'\n'
+  fi
 
   log INFO "✅ Updated: ${ok_count}"
   log INFO "⏭️ Excluded: ${skip_count}"

--- a/pve-update-notifier.sh
+++ b/pve-update-notifier.sh
@@ -14,7 +14,7 @@
 # Use this script at your own risk. The authors are not responsible for any
 # data loss, system instability, or service downtime caused by running it.
 
-SCRIPT_VERSION="v0.11.5"
+SCRIPT_VERSION="v0.11.6"
 
 # Add this path variable so Cron can find the required system commands
 export PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"

--- a/system-update-notifier.sh
+++ b/system-update-notifier.sh
@@ -2,7 +2,7 @@
 # System Update Notifier
 # Updates the host system via apt and sends a Telegram notification.
 
-SCRIPT_VERSION="v0.11.5"
+SCRIPT_VERSION="v0.11.6"
 
 export PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 


### PR DESCRIPTION
🎨 Palette: Conditionally align failure emojis in payloads

💡 What:
- Updated the report string building logic in `lxc-updater.sh` and `lxc-cleanup.sh` to use conditional statements for formatting the `fail_count` metric in the remote notification payload.
- Added a new journal entry to `.Jules/palette.md` to document this learning.
- Bumped `SCRIPT_VERSION` to `v0.11.6` across the script suite.

🎯 Why:
Previously, the remote Telegram/Gotify payload would hardcode a red cross (`❌ Failed: 0`) even when the failure count was zero. This created a false-positive visual alarm for users scanning their notifications. The payload now correctly mirrors the local logging logic (`✅ Failed: 0` when zero failures occur), reducing cognitive load and unnecessary panic.

📸 Before/After:
Before: `❌ Failed: 0`
After: `✅ Failed: 0` (or `❌ Failed: 1` if > 0)

♿ Accessibility:
Clearer, more accurate visual indicators (emojis) reduce cognitive load and prevent false alarms for users relying on quick scannability.

---
*PR created automatically by Jules for task [7963482921654937420](https://jules.google.com/task/7963482921654937420) started by @spupuz*