### PR TITLE
🛡️ Sentinel: [CRITICAL/HIGH] Fix symlink race condition in /tmp cleanup

### DIFF
--- a/lxc-cleanup.sh
+++ b/lxc-cleanup.sh
@@ -30,7 +30,7 @@
 
 set -Eeuo pipefail
 
-SCRIPT_VERSION="v0.11.5"
+SCRIPT_VERSION="v0.11.6"
 
 # --- LOGGING ---
 LOG_STDOUT="${LOG_STDOUT:-yes}" # Set to "no" to disable console output (useful for cron)
@@ -489,7 +489,7 @@ fi
 
 # 4. DOCKER CONTAINERS /tmp (old files in writable layers)
 if [ "${safe_clean_docker_tmp}" = "yes" ] && command -v docker >/dev/null 2>&1; then
-  step DOCKER_TMP 'for dc in \$(docker ps -q 2>/dev/null); do [ -n "\$dc" ] || continue; docker exec "\$dc" sh -c "find /tmp -mindepth 1 -mtime +7 -exec rm -rf {} +" >/dev/null 2>&1 || true; done'
+  step DOCKER_TMP 'for dc in \$(docker ps -q 2>/dev/null); do [ -n "\$dc" ] || continue; docker exec "\$dc" sh -c "find /tmp -mindepth 1 -mtime +7 -delete" >/dev/null 2>&1 || true; done'
 fi
 
 # 5. USER CACHES (~/.cache, npm, pnpm, go)
@@ -501,7 +501,7 @@ fi
 
 # 6. OLD /tmp FILES (older than 7 days)
 if [ "${safe_clean_old_tmp}" = "yes" ]; then
-  step TMP 'find /tmp -mindepth 1 -mtime +7 -exec rm -rf {} + 2>/dev/null'
+  step TMP 'find /tmp -mindepth 1 -mtime +7 -delete 2>/dev/null'
 fi
 
 after_total=\$(df_used)

--- a/lxc-updater.sh
+++ b/lxc-updater.sh
@@ -24,7 +24,7 @@
 
 set -Eeuo pipefail
 
-SCRIPT_VERSION="v0.11.5"
+SCRIPT_VERSION="v0.11.6"
 
 # --- LOGGING ---
 LOG_STDOUT="${LOG_STDOUT:-yes}" # Set to "no" to disable console output (useful for cron)
@@ -456,7 +456,7 @@ update_lxc() {
   read -r -d '' env_script << EOF || true
 # ⚡ Bolt: Batch /tmp cleanup into initial environment check to prevent spawning an extra pct process
 if [ "${safe_clean_tmp}" = "yes" ]; then
-  find /tmp -mindepth 1 -mtime +7 -exec rm -rf {} + 2>/dev/null || true
+  find /tmp -mindepth 1 -mtime +7 -delete 2>/dev/null || true
 fi
 
 APP_CMD=""

--- a/pve-update-notifier.sh
+++ b/pve-update-notifier.sh
@@ -14,7 +14,7 @@
 # Use this script at your own risk. The authors are not responsible for any
 # data loss, system instability, or service downtime caused by running it.
 
-SCRIPT_VERSION="v0.11.5"
+SCRIPT_VERSION="v0.11.6"
 
 # Add this path variable so Cron can find the required system commands
 export PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"

--- a/system-update-notifier.sh
+++ b/system-update-notifier.sh
@@ -2,7 +2,7 @@
 # System Update Notifier
 # Updates the host system via apt and sends a Telegram notification.
 
-SCRIPT_VERSION="v0.11.5"
+SCRIPT_VERSION="v0.11.6"
 
 export PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 


### PR DESCRIPTION
🚨 **Severity**: HIGH/CRITICAL

💡 **Vulnerability**:
The scripts used the pattern `find /tmp ... -exec rm -rf {} +` to clean up temporary files inside `/tmp` (both on the host and inside containers). `/tmp` is a world-writable, sticky directory. A malicious local user (or a compromised unprivileged container process) could create a directory in `/tmp`, wait for the script to begin the cleanup process, and rapidly replace the directory with a symlink to a sensitive location (e.g., `/etc` or `/var/lib`). If timed correctly, `rm -rf` would follow the symlink and delete the target contents.

🎯 **Impact**:
Local Privilege Escalation or Denial of Service (DoS) through arbitrary file deletion.

🔧 **Fix**:
Replaced the `find ... -exec rm -rf {} +` logic with the native `find ... -delete` action. The `-delete` action inherently protects against this race condition because it uses `unlinkat()` directly and strictly refuses to follow symlinks to directories. Additionally, bumped `SCRIPT_VERSION` to `v0.11.6` across all related scripts.

✅ **Verification**:
- Local test scripts (`./scripts/test_app_cmd_sanitize.sh`, `./scripts/test_ux_mirrors.sh`) execute successfully without regression.
- The `rm -rf` pattern for `/tmp` cleanup has been completely removed from `lxc-cleanup.sh` and `lxc-updater.sh`.

---
*PR created automatically by Jules for task [11066037119255736404](https://jules.google.com/task/11066037119255736404) started by @spupuz*