### PR TITLE
🛡️ Sentinel: [HIGH] Fix arbitrary file deletion via symlink attack in cache cleanup

### DIFF
--- a/lxc-cleanup.sh
+++ b/lxc-cleanup.sh
@@ -458,16 +458,16 @@ before_total=\$(df_used)
 if [ "${safe_clean_pkg_cache}" = "yes" ]; then
   case "\$PKG_MGR" in
     apt-get)
-      step PKG_CACHE 'apt-get autoremove -y --purge >/dev/null 2>&1; apt-get clean >/dev/null 2>&1; rm -rf /var/lib/apt/lists/* >/dev/null 2>&1'
+      step PKG_CACHE 'apt-get autoremove -y --purge >/dev/null 2>&1; apt-get clean >/dev/null 2>&1; find /var/lib/apt/lists -mindepth 1 -delete >/dev/null 2>&1 || true'
       ;;
     apk)
-      step PKG_CACHE 'apk cache clean >/dev/null 2>&1; rm -rf /var/cache/apk/* >/dev/null 2>&1'
+      step PKG_CACHE 'apk cache clean >/dev/null 2>&1; find /var/cache/apk -mindepth 1 -delete >/dev/null 2>&1 || true'
       ;;
     dnf)
-      step PKG_CACHE 'dnf clean all >/dev/null 2>&1; rm -rf /var/cache/dnf/* >/dev/null 2>&1'
+      step PKG_CACHE 'dnf clean all >/dev/null 2>&1; find /var/cache/dnf -mindepth 1 -delete >/dev/null 2>&1 || true'
       ;;
     yum)
-      step PKG_CACHE 'yum clean all >/dev/null 2>&1; rm -rf /var/cache/yum/* >/dev/null 2>&1'
+      step PKG_CACHE 'yum clean all >/dev/null 2>&1; find /var/cache/yum -mindepth 1 -delete >/dev/null 2>&1 || true'
       ;;
   esac
 fi
@@ -496,7 +496,7 @@ fi
 # 🛡️ Sentinel Security Fix: Prevent arbitrary file deletion via symlink attack in user cache cleanup
 # Check if cache directories are actual directories and not symlinks before recursively removing their contents
 if [ "${safe_clean_user_cache}" = "yes" ]; then
-  step USER_CACHE 'for home in /root /home/*; do [ -d "\$home" ] || continue; for dir in "\$home"/.cache "\$home"/.npm/_cacache "\$home"/.local/share/pnpm/store "\$home"/go/pkg/mod/cache; do [ -d "\$dir" ] && [ ! -L "\$dir" ] && rm -rf "\$dir"/* >/dev/null 2>&1 || true; done; done'
+  step USER_CACHE 'for home in /root /home/*; do [ -d "\$home" ] || continue; for dir in "\$home"/.cache "\$home"/.npm/_cacache "\$home"/.local/share/pnpm/store "\$home"/go/pkg/mod/cache; do [ -d "\$dir" ] && [ ! -L "\$dir" ] && find "\$dir" -mindepth 1 -delete >/dev/null 2>&1 || true; done; done'
 fi
 
 # 6. OLD /tmp FILES (older than 7 days)


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** The `lxc-cleanup.sh` script used `rm -rf /var/.../*` and `rm -rf "$dir"/*` with shell globbing to delete package manager caches and user caches inside containers. This created a symlink Time-Of-Check to Time-Of-Use (TOCTOU) vulnerability where a compromised container process could swap a directory or file for a symlink just as the script was running, tricking the root-executed `rm -rf` into following the symlink and deleting arbitrary files on the host/container.
🎯 **Impact:** Potential arbitrary file deletion and denial of service inside the container or mounted paths.
🔧 **Fix:** Replaced the vulnerable `rm -rf /*` globbing with `find ... -mindepth 1 -delete`. The `find -delete` action safely uses `unlinkat()` under the hood and explicitly refuses to follow symlinks, neutralizing the TOCTOU vulnerability entirely.
✅ **Verification:** Verified by checking that all package manager (apt/apk/dnf/yum) and user cache cleanup steps now safely utilize `find -delete`. Local test scripts (`test_app_cmd_sanitize.sh` and `test_ux_mirrors.sh`) execute successfully without regressions. Added a journal entry to document the risk.

---
*PR created automatically by Jules for task [1535482313703703484](https://jules.google.com/task/1535482313703703484) started by @spupuz*