### PR TITLE
🛡️ Sentinel: [HIGH] Fix symlink TOCTOU vulnerabilities in cleanup

### DIFF
--- a/lxc-cleanup.sh
+++ b/lxc-cleanup.sh
@@ -458,16 +458,16 @@ before_total=\$(df_used)
 if [ "${safe_clean_pkg_cache}" = "yes" ]; then
   case "\$PKG_MGR" in
     apt-get)
-      step PKG_CACHE 'apt-get autoremove -y --purge >/dev/null 2>&1; apt-get clean >/dev/null 2>&1; rm -rf /var/lib/apt/lists/* >/dev/null 2>&1'
+      step PKG_CACHE 'apt-get autoremove -y --purge >/dev/null 2>&1; apt-get clean >/dev/null 2>&1; [ -d /var/lib/apt/lists ] && find /var/lib/apt/lists -mindepth 1 -delete >/dev/null 2>&1 || true'
       ;;
     apk)
-      step PKG_CACHE 'apk cache clean >/dev/null 2>&1; rm -rf /var/cache/apk/* >/dev/null 2>&1'
+      step PKG_CACHE 'apk cache clean >/dev/null 2>&1; [ -d /var/cache/apk ] && find /var/cache/apk -mindepth 1 -delete >/dev/null 2>&1 || true'
       ;;
     dnf)
-      step PKG_CACHE 'dnf clean all >/dev/null 2>&1; rm -rf /var/cache/dnf/* >/dev/null 2>&1'
+      step PKG_CACHE 'dnf clean all >/dev/null 2>&1; [ -d /var/cache/dnf ] && find /var/cache/dnf -mindepth 1 -delete >/dev/null 2>&1 || true'
       ;;
     yum)
-      step PKG_CACHE 'yum clean all >/dev/null 2>&1; rm -rf /var/cache/yum/* >/dev/null 2>&1'
+      step PKG_CACHE 'yum clean all >/dev/null 2>&1; [ -d /var/cache/yum ] && find /var/cache/yum -mindepth 1 -delete >/dev/null 2>&1 || true'
       ;;
   esac
 fi
@@ -496,7 +496,7 @@ fi
 # 🛡️ Sentinel Security Fix: Prevent arbitrary file deletion via symlink attack in user cache cleanup
 # Check if cache directories are actual directories and not symlinks before recursively removing their contents
 if [ "${safe_clean_user_cache}" = "yes" ]; then
-  step USER_CACHE 'for home in /root /home/*; do [ -d "\$home" ] || continue; for dir in "\$home"/.cache "\$home"/.npm/_cacache "\$home"/.local/share/pnpm/store "\$home"/go/pkg/mod/cache; do [ -d "\$dir" ] && [ ! -L "\$dir" ] && rm -rf "\$dir"/* >/dev/null 2>&1 || true; done; done'
+  step USER_CACHE 'for home in /root /home/*; do [ -d "\$home" ] || continue; for dir in "\$home"/.cache "\$home"/.npm/_cacache "\$home"/.local/share/pnpm/store "\$home"/go/pkg/mod/cache; do [ -d "\$dir" ] && [ ! -L "\$dir" ] && find "\$dir" -mindepth 1 -delete >/dev/null 2>&1 || true; done; done'
 fi
 
 # 6. OLD /tmp FILES (older than 7 days)


### PR DESCRIPTION
🚨 **Severity:** HIGH
💡 **Vulnerability:** Deleting wildcard directory contents using `rm -rf $dir/*` in root-executed shell scripts introduces a Time-Of-Check to Time-Of-Use (TOCTOU) vulnerability. Even if `$dir` is confirmed not to be a symlink via `[ ! -L $dir ]` immediately prior to the execution, a malicious user could swap the directory or its contents with a symlink right before the `rm` command executes. Because the wildcard is evaluated by the shell (which follows symlinks by default during path expansion), this allows arbitrary file deletion.
🎯 **Impact:** Local privilege escalation and arbitrary data destruction (e.g., if a user cache directory is replaced with a symlink to `/`).
🔧 **Fix:** Replaced the unsafe `rm -rf $dir/*` pattern with `[ -d $dir ] && find $dir -mindepth 1 -delete || true`. The `find ... -delete` approach safely uses `unlinkat()` which does not traverse symlinks, completely neutralizing the TOCTOU attack vector. The `[ -d ]` check was added because `find` returns a non-zero exit code if the directory is missing (which would break the script execution), unlike `rm -rf /*` which silently ignores non-expanded globs.
✅ **Verification:** Verified by code review and by running the `./scripts/test_app_cmd_sanitize.sh` and `./scripts/test_ux_mirrors.sh` test scripts.

---
*PR created automatically by Jules for task [9691607213069323056](https://jules.google.com/task/9691607213069323056) started by @spupuz*