### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix arbitrary command execution via df parsing

### DIFF
--- a/lxc-cleanup.sh
+++ b/lxc-cleanup.sh
@@ -429,6 +429,8 @@ df_used() {
       header=0
       continue
     fi
+    # 🛡️ Sentinel Security Fix: Sanitize df variables before arithmetic evaluation
+    used="\${used//[^0-9]/}"
     echo "\$used"
     break
   done <<< "\$(df -P / 2>/dev/null)"

--- a/pve-update-notifier.sh
+++ b/pve-update-notifier.sh
@@ -398,6 +398,11 @@ get_lxc_disk_summary() {
       fi
     done <<< "$df_out"
 
+    # 🛡️ Sentinel Security Fix: Sanitize df variables before arithmetic evaluation
+    # to prevent arbitrary command execution via command substitution in output.
+    used="${used//[^0-9]/}"
+    size="${size//[^0-9]/}"
+
     [[ -n "$used" && -n "$size" && -n "$pct" ]] || continue
     [[ "$pct" =~ ^[0-9]+$ ]] || continue
 


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: Proxmox LXC scripts parse output of `df` executed inside a container and evaluate the variables in Bash arithmetic context (`$(( ... ))`). A malicious container can provide output like `a[$(cmd)]` causing arbitrary code execution as root on the host.
🎯 Impact: Local Privilege Escalation / RCE on Proxmox host from an unprivileged container.
🔧 Fix: Added explicit stripping of non-numeric characters before variable arithmetic evaluation (`used="${used//[^0-9]/}"`).
✅ Verification: Ran `scripts/test_df_inject.sh` mocking payload and verifying the check properly sanitizes it.

---
*PR created automatically by Jules for task [2976383262343969960](https://jules.google.com/task/2976383262343969960) started by @spupuz*